### PR TITLE
only track a page event on pushState for new pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,16 @@ yarn add @unifygtm/intent-client
 After installing the package, you must initialize it in your application code:
 
 ```TypeScript
-import { UnifyIntentClient } from '@unifygtm/intent-client';
+import { UnifyIntentClient, UnifyIntentClientConfig } from '@unifygtm/intent-client';
 
-const unify = new UnifyIntentClient('YOUR_PUBLIC_UNIFY_API_KEY');
+const writeKey = 'YOUR_PUBLIC_API_KEY';
+
+const config: UnifyIntentClientConfig = {
+  autoPage: true,
+  autoIdentify: false,
+};
+
+const unify = new UnifyIntentClient(writeKey, config);
 ```
 
 Once the client is initialized it will be immediately ready for use. See [Usage](#usage) below for how to use the client after installing.
@@ -66,7 +73,7 @@ In either case, this behavior can be enabled or disabled programmatically via th
 ```TypeScript
 // Initialize the client and tell it to automatically monitor pages
 const unify = new UnifyIntentClient(
-  'YOUR_PUBLIC_UNIFY_API_KEY',
+  'YOUR_PUBLIC_API_KEY',
   { autoPage: true },
 );
 
@@ -82,7 +89,7 @@ unify.startAutoPage();
 You can also manually trigger a page event with the `page` method on the client. This is useful when you do not want to trigger page events for _every_ page.
 
 ```TypeScript
-const unify = new UnifyIntentClient('YOUR_PUBLIC_UNIFY_API_KEY');
+const unify = new UnifyIntentClient('YOUR_PUBLIC_API_KEY');
 
 // Trigger a page event for whatever page the user is currently on
 unify.page();
@@ -108,7 +115,7 @@ In either case, this behavior can be enabled or disabled programmatically via th
 ```TypeScript
 // Initialize the client and tell it to automatically monitor inputs
 const unify = new UnifyIntentClient(
-  'YOUR_PUBLIC_UNIFY_API_KEY',
+  'YOUR_PUBLIC_API_KEY',
   { autoIdentify: true },
 );
 
@@ -124,7 +131,7 @@ unify.startAutoIdentify();
 You can also manually trigger an identify event with the `identify` method on the client. This is useful when users log-in with OAuth or SSO, for example, because they do not enter their email into an input on the page.
 
 ```TypeScript
-const unify = new UnifyIntentClient('YOUR_PUBLIC_UNIFY_API_KEY');
+const unify = new UnifyIntentClient('YOUR_PUBLIC_API_KEY');
 
 // However you determine the currently logged-in user
 const currentUser = getCurrentUser();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unifygtm/intent-client",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "type": "module",
   "description": "JavaScript client for interacting with the Unify Intent API in the browser.",
   "keywords": [

--- a/src/client/unify-intent-agent.ts
+++ b/src/client/unify-intent-agent.ts
@@ -93,8 +93,16 @@ export default class UnifyIntentAgent {
     // `pushState` is usually triggered to navigate to a new page
     const pushState = history.pushState;
     history.pushState = (...args) => {
+      // Get location before history changes
+      const oldLocation = { ...window.location };
+
+      // Update history
       pushState.apply(history, args);
-      this.maybeTrackPage();
+
+      // Compare old location to new location and maybe track page event
+      if (isNewPage(oldLocation, window.location)) {
+        this.maybeTrackPage();
+      }
     };
 
     // Sometimes `replaceState` is used to navigate to a new page, but

--- a/src/tests/client/unify-intent-agent.unit.test.ts
+++ b/src/tests/client/unify-intent-agent.unit.test.ts
@@ -83,18 +83,24 @@ describe('UnifyIntentAgent', () => {
       agent.stopAutoPage();
     });
 
-    it('tracks page events for history pushState', () => {
-      history.pushState(
-        {},
-        '',
-        `${location.protocol}//${location.hostname}/${uuidv4()}`,
-      );
-      expect(mockedPageActivity.track).toHaveBeenCalledTimes(1);
-    });
+    describe('history.pushState', () => {
+      it('tracks page events for new pages', () => {
+        history.pushState(
+          {},
+          '',
+          `${location.protocol}//${location.hostname}/${uuidv4()}`,
+        );
+        expect(mockedPageActivity.track).toHaveBeenCalledTimes(1);
+      });
 
-    it('tracks page events for window popstate', () => {
-      window.dispatchEvent(new Event('popstate'));
-      expect(mockedPageActivity.track).toHaveBeenCalledTimes(1);
+      it('does not track page events for the same page', () => {
+        history.pushState(
+          {},
+          '',
+          `${location.protocol}//${location.hostname}${location.pathname}?someParam=True`,
+        );
+        expect(mockedPageActivity.track).not.toHaveBeenCalled();
+      });
     });
 
     describe('history.replaceState', () => {
@@ -115,6 +121,11 @@ describe('UnifyIntentAgent', () => {
         );
         expect(mockedPageActivity.track).not.toHaveBeenCalled();
       });
+    });
+
+    it('tracks page events for window popstate', () => {
+      window.dispatchEvent(new Event('popstate'));
+      expect(mockedPageActivity.track).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
There is a bug in the auto-page tracking for SPAs. I made the assumption that `history.pushState` would only ever be called if the page being navigated to is actually different than the current page, but apparently that's not true. It's totally possible to misuse `history.pushState` and call it many times for the same page you're currently on.

This PR fixes this by doing the same thing we already do for `history.replaceState`, which is to verify that the new page being navigated to is actually different than the current page before logging a page event.