### PR TITLE
Make page event pathname customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ unify.mount();
 
 // Trigger a page event for whatever page the user is currently on
 unify.page();
+
+// Trigger a page event for a custom page that the user is not necessarily on
+unify.page({ pathname: '/some-custom-page' });
 ```
 
 ### Identify Events

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unifygtm/intent-client",
-  "version": "1.0.12",
+  "version": "1.1.0",
   "description": "JavaScript client for interacting with the Unify Intent API in the browser.",
   "keywords": [
     "unify",

--- a/src/client/activities/page.ts
+++ b/src/client/activities/page.ts
@@ -1,4 +1,9 @@
-import { AnalyticsEventType, PageEventData } from '../../types';
+import {
+  AnalyticsEventType,
+  PageEventData,
+  PageEventOptions,
+  UnifyIntentContext,
+} from '../../types';
 import { UNIFY_INTENT_V1_URL } from '../constants';
 import { getCurrentPageProperties } from '../utils/helpers';
 import Activity from './activity';
@@ -9,6 +14,13 @@ export const UNIFY_INTENT_PAGE_URL = `${UNIFY_INTENT_V1_URL}/page`;
  * Activity for logging a `page` event via the Unify Intent Client.
  */
 export class PageActivity extends Activity<PageEventData> {
+  private readonly _options?: PageEventOptions;
+
+  constructor(intentContext: UnifyIntentContext, options?: PageEventOptions) {
+    super(intentContext);
+    this._options = options;
+  }
+
   protected getActivityType(): AnalyticsEventType {
     return 'page' as PageEventData['type'];
   }
@@ -19,6 +31,6 @@ export class PageActivity extends Activity<PageEventData> {
 
   protected getActivityData = (): PageEventData => ({
     type: 'page' as PageEventData['type'],
-    properties: getCurrentPageProperties(),
+    properties: getCurrentPageProperties(this._options?.pathname),
   });
 }

--- a/src/client/index.ts
+++ b/src/client/index.ts
@@ -1,3 +1,3 @@
-export { UnifyIntentClientConfig } from '../types';
+export { UnifyIntentClientConfig, PageEventOptions } from '../types';
 
 export { default as UnifyIntentClient } from './unify-intent-client';

--- a/src/client/unify-intent-client.ts
+++ b/src/client/unify-intent-client.ts
@@ -1,4 +1,8 @@
-import { UnifyIntentClientConfig, UnifyIntentContext } from '../types';
+import {
+  PageEventOptions,
+  UnifyIntentClientConfig,
+  UnifyIntentContext,
+} from '../types';
 import { IdentifyActivity, PageActivity } from './activities';
 import { IdentityManager, SessionManager } from './managers';
 import UnifyApiClient from './unify-api-client';
@@ -115,13 +119,16 @@ export default class UnifyIntentClient {
   };
 
   /**
-   * This function logs a page view for the current page to
-   * the Unify Intent API.
+   * This function logs a page view for the current page or the page
+   * specified in options to the Unify Intent API.
+   *
+   * @param options - options which can be used to customize the page
+   *        event which is logged. See `PageEventOptions` for details.
    */
-  public page = () => {
+  public page = (options?: PageEventOptions) => {
     if (!this._mounted) return;
 
-    const action = new PageActivity(this._context);
+    const action = new PageActivity(this._context, options);
     action.track();
   };
 

--- a/src/client/utils/helpers.ts
+++ b/src/client/utils/helpers.ts
@@ -18,14 +18,48 @@ export function getTimeForMinutesInFuture(
 
 /**
  * Gets the properties of the current page used in intent logging.
+ *
+ * @param pathname - optional pathname to use instead of the current pathname
+ *        when constructing page properties. This allows supporting logging
+ *        a page other than the one the user is currently on.
+ * @returns a set of properties for the specified or current page
  */
-export const getCurrentPageProperties = (): PageProperties => ({
-  path: window.location.pathname,
+export const getCurrentPageProperties = (
+  pathname?: string,
+): PageProperties => ({
+  path: pathname ?? window.location.pathname,
   query: parseUrlQueryParams(window.location.href),
   referrer: document.referrer,
   title: document.title,
-  url: window.location.href,
+  url:
+    pathname !== undefined
+      ? getLocationHrefWithCustomPath({ location: window.location, pathname })
+      : window.location.href,
 });
+
+/**
+ * This function will replace the pathname for a given `location.href`
+ * with the specified custom pathname. This is more complicated than
+ * a simple `replace` because the pathname can be simply "/" which can
+ * occur in the URL before the pathname (i.e. after the protocol).
+ *
+ * @param location - the location containing the `href` to replace the
+ *        pathname for
+ * @param pathname - the custom pathname to replace the existing one with
+ * @returns the `location.href` with `pathname` replacing the existing pathname
+ */
+export function getLocationHrefWithCustomPath({
+  location,
+  pathname,
+}: {
+  location: Location;
+  pathname: string;
+}) {
+  const url = new URL(location.href);
+  url.pathname = pathname;
+
+  return url.toString();
+}
 
 /**
  * Gets the current user agent data used in intent logging.

--- a/src/tests/client/activities/page.unit.test.ts
+++ b/src/tests/client/activities/page.unit.test.ts
@@ -1,4 +1,4 @@
-import { anyObject, mockReset } from 'jest-mock-extended';
+import { anyObject, mockReset, objectContainsValue } from 'jest-mock-extended';
 
 import {
   PageActivity,
@@ -37,6 +37,18 @@ describe('PageActivity', () => {
       const data = mockContext.apiClient.post.mock.calls[0][1] as PageEventData;
       expect(data.type).toEqual('page');
       expect(data.properties).toEqual(anyObject());
+    });
+
+    it('uses the optional pathname for page properties when provided', () => {
+      const CUSTOM_PAGE = '/some-custom-page';
+      const page = new PageActivity(mockContext, { pathname: CUSTOM_PAGE });
+      page.track();
+      expect(mockContext.apiClient.post).toHaveBeenCalledWith(
+        UNIFY_INTENT_PAGE_URL,
+        anyObject(),
+      );
+      const data = mockContext.apiClient.post.mock.calls[0][1] as PageEventData;
+      expect(data.properties?.path).toEqual('/some-custom-page');
     });
   });
 });

--- a/src/tests/client/utils/helpers.unit.test.ts
+++ b/src/tests/client/utils/helpers.unit.test.ts
@@ -1,0 +1,59 @@
+import { getLocationHrefWithCustomPath } from '../../../client/utils/helpers';
+
+const TEST_CUSTOM_PATH = '/some-custom-path';
+
+describe('helpers', () => {
+  describe('getLocationHrefWithCustomPath', () => {
+    it('correctly replaces href pathname with custom pathname', () => {
+      const TEST_LOCATION = { ...window.location };
+      TEST_LOCATION.href = 'https://www.unifygtm.com/pricing?searchParam=3';
+      TEST_LOCATION.pathname = '/pricing';
+
+      const result = getLocationHrefWithCustomPath({
+        location: TEST_LOCATION,
+        pathname: TEST_CUSTOM_PATH,
+      });
+      expect(result).toEqual(
+        'https://www.unifygtm.com/some-custom-path?searchParam=3',
+      );
+    });
+
+    it('correctly replaces href pathname with custom pathname for localhost', () => {
+      const TEST_LOCATION = { ...window.location };
+      TEST_LOCATION.href = 'http://localhost:8000/pricing?searchParam=3';
+      TEST_LOCATION.pathname = '/pricing';
+
+      const result = getLocationHrefWithCustomPath({
+        location: TEST_LOCATION,
+        pathname: TEST_CUSTOM_PATH,
+      });
+      expect(result).toEqual(
+        'http://localhost:8000/some-custom-path?searchParam=3',
+      );
+    });
+
+    it('correctly replaces href pathname with custom pathname for root path', () => {
+      const TEST_LOCATION = { ...window.location };
+      TEST_LOCATION.href = 'https://www.unifygtm.com/';
+      TEST_LOCATION.pathname = '/';
+
+      const result = getLocationHrefWithCustomPath({
+        location: TEST_LOCATION,
+        pathname: TEST_CUSTOM_PATH,
+      });
+      expect(result).toEqual('https://www.unifygtm.com/some-custom-path');
+    });
+
+    it('correctly replaces href pathname with custom pathname for empty path', () => {
+      const TEST_LOCATION = { ...window.location };
+      TEST_LOCATION.href = 'https://www.unifygtm.com';
+      TEST_LOCATION.pathname = '';
+
+      const result = getLocationHrefWithCustomPath({
+        location: TEST_LOCATION,
+        pathname: TEST_CUSTOM_PATH,
+      });
+      expect(result).toEqual('https://www.unifygtm.com/some-custom-path');
+    });
+  });
+});

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,17 @@ export interface UnifyIntentContext {
   identityManager: IdentityManager;
 }
 
+/**
+ * Options which can be used when logging a page event via the intent client.
+ */
+export interface PageEventOptions {
+  /**
+   * Optional pathname to use in place of the current pathname,
+   * e.g. "/some-custom-page/v1"
+   */
+  pathname?: string;
+}
+
 export type ClientSession = {
   sessionId: string;
   expiration: number;


### PR DESCRIPTION
There are some cases where we want to log a page event for a pathname other than the current location pathname.

This PR adds an optional `options` param to the `page` method on the intent client. One of the options is a `pathname` which will be used when constructing the page properties to set the `pathname` and `href` attributes of the properties object.