### PR TITLE
Add support for person-level identity from Navattic iframes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unifygtm/intent-client",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "JavaScript client for interacting with the Unify Intent API in the browser.",
   "keywords": [
     "unify",

--- a/src/client/agent/constants.ts
+++ b/src/client/agent/constants.ts
@@ -1,9 +1,12 @@
 import { DefaultEventType } from './types/default';
 
 export const DEFAULT_FORMS_IFRAME_ORIGIN = 'https://forms.default.com';
+export const NAVATTIC_IFRAME_ORIGIN = 'https://capture.navattic.com';
 
 export const DEFAULT_FORM_EVENT_TYPES: DefaultEventType[] = [
   DefaultEventType.FORM_COMPLETED,
   DefaultEventType.FORM_PAGE_SUBMITTED,
   DefaultEventType.FORM_PAGE_SUBMITTED_V2,
 ];
+
+export const NAVATTIC_USER_EMAIL_KEY = 'user.email';

--- a/src/client/agent/types/navattic.ts
+++ b/src/client/agent/types/navattic.ts
@@ -1,0 +1,182 @@
+/**
+ * All possible event types emitted by Navattic.
+ */
+export enum NavatticEventType {
+  VIEW_STEP = 'VIEW_STEP',
+  START_FLOW = 'START_FLOW',
+  COMPLETE_FLOW = 'COMPLETE_FLOW',
+  START_CHECKLIST = 'START_CHECKLIST',
+  OPEN_CHECKLIST = 'OPEN_CHECKLIST',
+  CLOSE_CHECKLIST = 'CLOSE_CHECKLIST',
+  COMPLETE_TASK = 'COMPLETE_TASK',
+  CONVERTED = 'CONVERTED',
+  NAVIGATE = 'NAVIGATE',
+  IDENTIFY_USER = 'IDENTIFY_USER',
+  ENGAGE = 'ENGAGE',
+}
+
+/**
+ * All possible sources for user attributes identifiable by Navattic.
+ */
+export enum NavatticAttributeSource {
+  FORM = 'FORM',
+  IDENTIFY = 'IDENTIFY',
+  QUERY_PARAMS = 'QUERY_PARAMS',
+  SHARE_LINK = 'SHARE_LINK',
+  ENRICHMENT = 'ENRICHMENT',
+  OTHER = 'OTHER',
+}
+
+export interface NavatticProject {
+  /**
+   * ID of the project.
+   */
+  id: string;
+
+  /**
+   * Name of the project.
+   */
+  name: string;
+}
+
+export interface NavatticFlow {
+  /**
+   * ID of the flow.
+   */
+  id: string;
+
+  /**
+   * Name of the flow.
+   */
+  name: string;
+}
+
+export interface NavatticStep {
+  /**
+   * Name of the step.
+   */
+  name: string;
+
+  /**
+   * Zero-based index of the step in the flow.
+   */
+  indx: number;
+}
+
+export interface NavatticChecklist {
+  /**
+   * ID of the checklist.
+   */
+  id: string;
+
+  /**
+   * Name of the checklist.
+   */
+  name: string;
+}
+
+export interface NavatticTask {
+  /**
+   * ID of the task.
+   */
+  id: string;
+
+  /**
+   * Title of the task.
+   */
+  title: string;
+}
+
+export interface NavatticClientSideMetadata {
+  browser: string;
+  browser_version: string;
+  current_url: string;
+  device: string;
+  gclid?: string;
+  host: string;
+  os: string;
+  pathname: string;
+  query_strings: object;
+  referrer: string;
+  referring_domain: string;
+  screen_height: number;
+  screen_width: number;
+}
+
+export type NavatticEventData =
+  | BaseNavatticEventData
+  | NavatticNavigateEventData;
+
+/**
+ * Interface describing the expected payload of an event
+ * emitted by a Navattic iframe.
+ */
+export interface BaseNavatticEventData {
+  /**
+   * The type of the event.
+   */
+  type: NavatticEventType;
+
+  /**
+   * Project associated with the Navattic demo.
+   */
+  project: NavatticProject;
+
+  /**
+   * Flow that the user is currently in.
+   */
+  flow: NavatticFlow;
+
+  /**
+   * Current step of the flow the user is currently in.
+   */
+  step: NavatticStep;
+
+  /**
+   * If there is a checklist in the current project, the
+   * data associated with that checklist.
+   */
+  checklist?: NavatticChecklist;
+
+  /**
+   * If there is a checklist and the user is currently on the
+   * checklist, the current task from that list.
+   */
+  task?: NavatticTask;
+
+  /**
+   * IDs of tasks already completed by the user at this point.
+   */
+  completions: string[];
+
+  /**
+   * ID of the customer accessing the demo. Shows up at the URL:
+   * https://app.navattic.com/your-workspace/customers/{customerId}
+   */
+  customerId: string;
+
+  /**
+   * ID of the user's current Navattic session.
+   */
+  sessionId: string;
+
+  /**
+   * Metadata about the user's device, browser, etc.
+   */
+  clientSideMetadata: NavatticClientSideMetadata;
+
+  /**
+   * Attributes that have been identified for the user, grouped
+   * by the source they come from, e.g. a form-fill.
+   */
+  eventAttributes: Record<NavatticAttributeSource, { [key: string]: any }>;
+}
+
+export type NavatticNavigateEventData = BaseNavatticEventData & {
+  type: NavatticEventType.NAVIGATE;
+
+  /**
+   * URL of the link that the visitor navigated to.
+   */
+  url: string;
+};

--- a/src/client/agent/unify-intent-agent.ts
+++ b/src/client/agent/unify-intent-agent.ts
@@ -261,7 +261,6 @@ export class UnifyIntentAgent {
       const emailFromForm = event.data.eventAttributes.FORM?.[
         NAVATTIC_USER_EMAIL_KEY
       ] as string | undefined;
-      console.log(emailFromForm);
 
       // If there is a user email, identify the user
       if (emailFromForm) {


### PR DESCRIPTION
This PR adds handling for events emitted by Navattic iframes to get the user's email if there is one and log an identify event.

Tested on our marketing site and it works as expected.
