### PR TITLE
Add expires time to cookies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unifygtm/intent-client",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "JavaScript client for interacting with the Unify Intent API in the browser.",
   "keywords": [
     "unify",

--- a/src/client/storage/cookies.ts
+++ b/src/client/storage/cookies.ts
@@ -45,6 +45,7 @@ export class CookieStorageService extends StorageService {
   protected storeValue(key: string, encodedValue: string): void {
     Cookies.set(key, encodedValue, {
       domain: `.${getCurrentTopLevelDomain()}`,
+      expires: 365,
     });
   }
 }

--- a/src/tests/client/storage/cookies.unit.test.ts
+++ b/src/tests/client/storage/cookies.unit.test.ts
@@ -44,7 +44,7 @@ describe('CookieStorageService', () => {
       expect(CookiesMock.set).toHaveBeenCalledWith(
         encodeForStorage(`${TEST_WRITE_KEY}_anonymousUserId`),
         encodeForStorage(TEST_ANONYMOUS_USER_ID),
-        { domain: `.${getCurrentTopLevelDomain()}` },
+        { domain: `.${getCurrentTopLevelDomain()}`, expires: 365 },
       );
     });
 
@@ -54,7 +54,7 @@ describe('CookieStorageService', () => {
       expect(CookiesMock.set).toHaveBeenCalledWith(
         encodeForStorage(`ő_anonymousUserId`),
         encodeForStorage(TEST_ANONYMOUS_USER_ID),
-        { domain: `.${getCurrentTopLevelDomain()}` },
+        { domain: `.${getCurrentTopLevelDomain()}`, expires: 365 },
       );
     });
   });


### PR DESCRIPTION
So while looking into what might have caused a missing reveal, I stumbled upon something troubling in the docs for `js-cookie`, the package we use to manage the cookies that store anonymous user IDs.

It seems back when we first built the intent client, we made the mistake of thinking that _not_ providing an expiration time for cookies would default to them lasting forever. However it seems that is [incorrect](https://github.com/js-cookie/js-cookie?tab=readme-ov-file#expires), and the actual default behavior is that the cookie is deleted when the user _closes their browser_. We probably never stumbled upon this because we just don't close our browsers very often.

This... is a bit of an L. The consequence of this is essentially that any time a user closes their browser, the next time they visit a customer's website, they will be associated with a different anonymous user than from before they closed their browser. And if their identity was previously revealed, this new anonymous user will not have their identity revealed.

The one saving grace here is that most people probably don't close their browsers very often in this modern world of ours.