### PR TITLE
Get user email from Navattic event data properties

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unifygtm/intent-client",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "JavaScript client for interacting with the Unify Intent API in the browser.",
   "keywords": [
     "unify",

--- a/src/client/agent/constants.ts
+++ b/src/client/agent/constants.ts
@@ -10,3 +10,4 @@ export const DEFAULT_FORM_EVENT_TYPES: DefaultEventType[] = [
 ];
 
 export const NAVATTIC_USER_EMAIL_KEY = 'user.email';
+export const NAVATTIC_USER_EMAIL_PROPERTY = 'email';

--- a/src/client/agent/types/navattic.ts
+++ b/src/client/agent/types/navattic.ts
@@ -24,7 +24,23 @@ export enum NavatticAttributeSource {
   QUERY_PARAMS = 'QUERY_PARAMS',
   SHARE_LINK = 'SHARE_LINK',
   ENRICHMENT = 'ENRICHMENT',
+  REDUCER = 'REDUCER',
   OTHER = 'OTHER',
+}
+
+/**
+ * Known object types for Navattic event data.
+ */
+export enum NavatticObject {
+  COMPANY_ACCOUNT = 'COMPANY_ACCOUNT',
+  END_USER = 'END_USER',
+}
+
+/**
+ * Known capture methods for Navattic event data.
+ */
+export enum NavatticCaptureMethod {
+  DEMO = 'DEMO',
 }
 
 export interface NavatticProject {
@@ -85,6 +101,14 @@ export interface NavatticTask {
    * Title of the task.
    */
   title: string;
+}
+
+export interface NavatticEventDataProperty {
+  captureMethod: NavatticCaptureMethod;
+  object: NavatticObject;
+  source: NavatticAttributeSource;
+  name: string;
+  value: string;
 }
 
 export interface NavatticClientSideMetadata {
@@ -170,6 +194,11 @@ export interface BaseNavatticEventData {
    * by the source they come from, e.g. a form-fill.
    */
   eventAttributes: Record<NavatticAttributeSource, { [key: string]: any }>;
+
+  /**
+   * Data properties for the current end user, company account, etc.
+   */
+  properties?: NavatticEventDataProperty[];
 }
 
 export type NavatticNavigateEventData = BaseNavatticEventData & {

--- a/src/client/agent/unify-intent-agent.ts
+++ b/src/client/agent/unify-intent-agent.ts
@@ -6,9 +6,14 @@ import {
   DEFAULT_FORMS_IFRAME_ORIGIN,
   NAVATTIC_IFRAME_ORIGIN,
   NAVATTIC_USER_EMAIL_KEY,
+  NAVATTIC_USER_EMAIL_PROPERTY,
 } from './constants';
 import { DefaultEventData } from './types/default';
-import { NavatticEventData, NavatticEventType } from './types/navattic';
+import {
+  NavatticEventData,
+  NavatticEventType,
+  NavatticObject,
+} from './types/navattic';
 import { isDefaultFormEventData } from './utils';
 
 /**
@@ -276,6 +281,17 @@ export class UnifyIntentAgent {
         if (email) {
           this.maybeIdentifyInputEmail(email);
         }
+      }
+    } else {
+      const eventDataProperties = event.data.properties ?? [];
+      const endUserEmailProperty = eventDataProperties.find(
+        ({ object, name }) =>
+          object === NavatticObject.END_USER &&
+          name === NAVATTIC_USER_EMAIL_PROPERTY,
+      );
+
+      if (endUserEmailProperty) {
+        this.maybeIdentifyInputEmail(endUserEmailProperty.value);
       }
     }
   };


### PR DESCRIPTION
Looks like Navattic has changed their event data payload. Not sure if the old payload just doesn't work at all anymore, or if it just doesn't work for the Navattic product demo, but this PR adds support for the new structure of the payload.

I added unit tests and also this is wrapped in a try-catch so should be a pretty safe change.