### PR TITLE
Use `window.unifyBrowser` when `window.unify` has been overridden

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unifygtm/intent-client",
-  "version": "1.1.3",
+  "version": "1.2.0",
   "description": "JavaScript client for interacting with the Unify Intent API in the browser.",
   "keywords": [
     "unify",

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -1,4 +1,5 @@
 import { UnifyIntentClient } from '../client';
+import { isIntentClient } from '../client/utils/helpers';
 import { logUnifyError } from '../client/utils/logging';
 
 /**
@@ -10,7 +11,7 @@ export const initBrowser = function () {
   if (typeof window === 'undefined') return;
 
   // If the client has already been initialized, do nothing
-  if (window.unify !== undefined && !Array.isArray(window.unify)) {
+  if (isIntentClient(window.unify) || isIntentClient(window.unifyBrowser)) {
     logUnifyError({
       message:
         'UnifyIntentClient already exists on window, a new one will not be created.',

--- a/src/client/unify-intent-client.ts
+++ b/src/client/unify-intent-client.ts
@@ -7,12 +7,13 @@ import { IdentifyActivity, PageActivity } from './activities';
 import { IdentityManager, SessionManager } from './managers';
 import UnifyApiClient from './unify-api-client';
 import { UnifyIntentAgent } from './agent';
-import { validateEmail } from './utils/helpers';
+import { isIntentClient, validateEmail } from './utils/helpers';
 import { logUnifyError } from './utils/logging';
 
 declare global {
   interface Window {
     unify?: UnifyIntentClient;
+    unifyBrowser?: UnifyIntentClient;
   }
 }
 
@@ -51,7 +52,7 @@ export default class UnifyIntentClient {
     if (typeof window === 'undefined') return;
 
     // The client should never be instantiated more than once
-    if (window.unify !== undefined && !Array.isArray(window.unify)) {
+    if (isIntentClient(window.unify) || isIntentClient(window.unifyBrowser)) {
       logUnifyError({
         message:
           'UnifyIntentClient already exists on window, a new one will not be created.',
@@ -94,6 +95,7 @@ export default class UnifyIntentClient {
 
     // Set unify object on window to prevent multiple instantiations
     window.unify = this;
+    window.unifyBrowser = this;
   };
 
   /**
@@ -116,6 +118,7 @@ export default class UnifyIntentClient {
 
     this._mounted = false;
     window.unify = undefined;
+    window.unifyBrowser = undefined;
   };
 
   /**
@@ -236,6 +239,8 @@ export default class UnifyIntentClient {
 function flushUnifyQueue(unify: UnifyIntentClient) {
   const queue: [string, unknown[]][] = Array.isArray(window.unify)
     ? [...window.unify]
+    : Array.isArray(window.unifyBrowser)
+    ? [...window.unifyBrowser]
     : [];
 
   queue.forEach(([method, args]) => {

--- a/src/client/utils/helpers.ts
+++ b/src/client/utils/helpers.ts
@@ -2,6 +2,35 @@ import { PageProperties, UserAgentDataType } from '../../types';
 
 const EMAIL_REGEX = /^[A-Za-z0-9._+%-]+@[A-Za-z0-9.-]+[.][A-Za-z]+$/;
 
+const TEST_CLIENT_PROPERTIES = ['identify', 'page'];
+
+/**
+ * Helper function to check if a value is an instance of the global Unify
+ * Intent Client. The following checks are performend:
+ *
+ * 1. Is the value an object? The intent client will always be.
+ * 2. Is the value defined? For obvious reasons.
+ * 3. Is the value NOT an array? We temporarily stub the intent client as
+ *    an array in the global context to queue method calls before the client loads.
+ * 4. Are the expected properties in the object? This is to protect against
+ *    a bug where customers accidentally override the global variable we
+ *    normally store the intent client at by setting the `id` of an element
+ *    in the DOM equal to the same name. For example, creating a `<script>`
+ *    tag with `id="unify"` will override `window.unify` to be the `<script>`
+ *    HTML element.
+ *
+ * @param value - the value to check is an instance of the intent client
+ * @returns `true` if the value is an instance of the intent client, or else `false`
+ */
+export function isIntentClient(value: unknown) {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    TEST_CLIENT_PROPERTIES.every((property) => property in value)
+  );
+}
+
 /**
  * Gets a milliseconds since epoch for `minutes` in the future.
  *

--- a/src/tests/browser/browser.unit.test.ts
+++ b/src/tests/browser/browser.unit.test.ts
@@ -41,20 +41,25 @@ describe('Browser', () => {
   beforeEach(() => {
     document.body.innerHTML = MOCK_UNIFY_TAG_WRITE_KEY;
     window.unify = undefined;
+    window.unifyBrowser = undefined;
   });
 
   describe('initBrowser', () => {
     it('initializes a UnifyIntentClient on the window', () => {
       expect(window.unify).toBeFalsy();
+      expect(window.unifyBrowser).toBeFalsy();
       initBrowser();
       expect(window.unify).toBeTruthy();
+      expect(window.unifyBrowser).toBeTruthy();
     });
 
     it('falls back to data-api-key for legacy scripts', () => {
       document.body.innerHTML = MOCK_UNIFY_TAG_API_KEY;
       expect(window.unify).toBeFalsy();
+      expect(window.unifyBrowser).toBeFalsy();
       initBrowser();
       expect(window.unify).toBeTruthy();
+      expect(window.unifyBrowser).toBeTruthy();
     });
   });
 });

--- a/src/tests/client/unify-intent-client.unit.test.ts
+++ b/src/tests/client/unify-intent-client.unit.test.ts
@@ -32,6 +32,7 @@ jest.mock('../../client/activities', () => ({
 describe('UnifyIntentClient', () => {
   beforeEach(() => {
     window.unify = undefined;
+    window.unifyBrowser = undefined;
     mockReset(mockedIdentityManager);
     mockReset(mockedSessionManager);
     mockReset(mockedIntentAgent);
@@ -51,6 +52,25 @@ describe('UnifyIntentClient', () => {
     expect(mockedPageActivity.track).toHaveBeenCalledTimes(1);
     expect(mockedIdentifyActivity.track).toHaveBeenCalledTimes(1);
     expect(window.unify).toBeTruthy();
+    expect(window.unifyBrowser).toBeTruthy();
+
+    unify.unmount();
+  });
+
+  it('clears methods in the queue when window.unifyBrowser is initialized', () => {
+    window.unify = undefined;
+    // @ts-expect-error
+    window.unifyBrowser = [
+      ['page', []],
+      ['identify', ['solomon@unifygtm.com']],
+    ];
+    const unify = new UnifyIntentClient(TEST_WRITE_KEY);
+    unify.mount();
+
+    expect(mockedPageActivity.track).toHaveBeenCalledTimes(1);
+    expect(mockedIdentifyActivity.track).toHaveBeenCalledTimes(1);
+    expect(window.unify).toBeTruthy();
+    expect(window.unifyBrowser).toBeTruthy();
 
     unify.unmount();
   });

--- a/src/tests/client/unify-intent-client.unit.test.ts
+++ b/src/tests/client/unify-intent-client.unit.test.ts
@@ -5,6 +5,7 @@ import { IdentifyActivity, PageActivity } from '../../client/activities';
 import { IdentityManager, SessionManager } from '../../client/managers';
 import { UnifyIntentAgent } from '../../client/agent';
 import { TEST_WRITE_KEY } from '../mocks/data';
+import { isIntentClient } from '../../client/utils/helpers';
 
 const mockedIdentityManager = mock(IdentityManager.prototype);
 const mockedSessionManager = mock(SessionManager.prototype);
@@ -51,8 +52,8 @@ describe('UnifyIntentClient', () => {
 
     expect(mockedPageActivity.track).toHaveBeenCalledTimes(1);
     expect(mockedIdentifyActivity.track).toHaveBeenCalledTimes(1);
-    expect(window.unify).toBeTruthy();
-    expect(window.unifyBrowser).toBeTruthy();
+    expect(isIntentClient(window.unify)).toBeTruthy();
+    expect(isIntentClient(window.unifyBrowser)).toBeTruthy();
 
     unify.unmount();
   });
@@ -69,8 +70,8 @@ describe('UnifyIntentClient', () => {
 
     expect(mockedPageActivity.track).toHaveBeenCalledTimes(1);
     expect(mockedIdentifyActivity.track).toHaveBeenCalledTimes(1);
-    expect(window.unify).toBeTruthy();
-    expect(window.unifyBrowser).toBeTruthy();
+    expect(isIntentClient(window.unify)).toBeTruthy();
+    expect(isIntentClient(window.unifyBrowser)).toBeTruthy();
 
     unify.unmount();
   });

--- a/test.html
+++ b/test.html
@@ -4,33 +4,38 @@
     <meta charset="utf-8" />
     <script>
       !(function () {
-        window.unify ||
-          (window.unify = Object.assign(
+        var e = [
+          'identify',
+          'page',
+          'startAutoPage',
+          'stopAutoPage',
+          'startAutoIdentify',
+          'stopAutoIdentify',
+        ];
+        function t(o) {
+          return Object.assign(
             [],
-            [
-              'identify',
-              'page',
-              'startAutoPage',
-              'stopAutoPage',
-              'startAutoIdentify',
-              'stopAutoIdentify',
-            ].reduce(function (acc, m) {
-              acc[m] = function () {
-                unify.push([m, [].slice.call(arguments)]);
-                return unify;
-              };
-              return acc;
+            e.reduce(function (r, n) {
+              return (
+                (r[n] = function () {
+                  return o.push([n, [].slice.call(arguments)]), o;
+                }),
+                r
+              );
             }, {}),
-          ));
-        var s = document.createElement('script');
-        s.async = !0;
-        s.setAttribute('src', 'dist/js/browser/index.min.js');
-        s.setAttribute(
-          'data-api-key',
-          'wk_5fTtsDLJ_7vx9DsjPcr79yk4FweES727w59pxS8EJ',
-        );
-        s.setAttribute('id', 'unifytag');
-        (document.body || document.head).appendChild(s);
+          );
+        }
+        window.unify || (window.unify = t(window.unify)),
+          window.unifyBrowser || (window.unifyBrowser = t(window.unifyBrowser));
+        var n = document.createElement('script');
+        (n.async = !0),
+          n.setAttribute('src', 'dist/js/browser/index.min.js'),
+          n.setAttribute(
+            'data-api-key',
+            'wk_5fTtsDLJ_7vx9DsjPcr79yk4FweES727w59pxS8EJ',
+          ),
+          n.setAttribute('id', 'unifytag'),
+          (document.body || document.head).appendChild(n);
       })();
     </script>
   </head>


### PR DESCRIPTION
There is a pretty common source of user error when installing the intent client where NextJS users will embed the script with a `<Script>` component. When doing this, it's a requirement to include an `id` attribute on the `<Script>` and users almost always set this to `"unify"` because it seems pretty sensible. Unfortunately, this results in a `<script>` element being rendered in the DOM with this same ID, and this overrides `window.unify`. We check if `window.unify` is already an object, and if it is, we assume the intent client has already been initialized. We also use `window.unify` to queue method calls which might have been made before the intent client actually loaded. If this queue is overridden by the `<script>` element then this behavior will break.

This PR addresses this by using a new global field - `window.unifyBrowser` - to dequeue method calls and store the client. This is done in addition to the old `window.unify` to maintain backwards compatibility.

After this PR is deployed I will make another PR which updates the JS snippet on the settings page to queue methods on both `window.unify` and `window.unifyBrowser`.