### PR TITLE
Add functions to get event tracking payloads from intent client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unifygtm/intent-client",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "JavaScript client for interacting with the Unify Intent API in the browser.",
   "keywords": [
     "unify",

--- a/src/client/activities/activity.ts
+++ b/src/client/activities/activity.ts
@@ -21,10 +21,22 @@ abstract class Activity<TActivityData extends object> {
    * to the relevant Unify Intent activity URL.
    */
   public track(): void {
-    this._intentContext.apiClient.post(this.getActivityURL(), {
+    this._intentContext.apiClient.post(
+      this.getActivityURL(),
+      this.getTrackPayload(),
+    );
+  }
+
+  /**
+   * Gets the request payload required to track this activity. This is useful
+   * if you want to send the payload to a proxy server to perform the tracking
+   * server-side.
+   */
+  public getTrackPayload(): AnalyticsEventBase & TActivityData {
+    return {
       ...this.getBaseActivityPayload(),
       ...this.getActivityData(),
-    });
+    };
   }
 
   /**

--- a/src/client/unify-intent-client.ts
+++ b/src/client/unify-intent-client.ts
@@ -136,6 +136,23 @@ export default class UnifyIntentClient {
   };
 
   /**
+   * This function returns the request payload for tracking a page event.
+   * This is useful if you want to send the payload to a proxy server to
+   * perform the tracking server-side.
+   *
+   * @param options - options which can be used to customize the page
+   *        event which is tracked. See `PageEventOptions` for details.
+   * @returns if the client is mounted, the request payload to track a page
+   *          event, otherwise returns `undefined`
+   */
+  public getPagePayload = (options?: PageEventOptions) => {
+    if (!this._mounted) return;
+
+    const action = new PageActivity(this._context, options);
+    return action.getTrackPayload();
+  };
+
+  /**
    * This function logs an identify event for the given email address
    * to the Unify Intent API. Unify will associate this email address
    * with the current user's session and all related activities.
@@ -157,6 +174,28 @@ export default class UnifyIntentClient {
     }
 
     return false;
+  };
+
+  /**
+   * This function returns the request payload for tracking an identify event.
+   * This is useful if you want to send the payload to a proxy server to
+   * perform the tracking server-side.
+   *
+   * @param email - the email address to log an identify event for
+   * @returns if the client is mounted and `email` is a valid email address,
+   *          the request payload to track an identify event, otherwise
+   *          returns `undefined`
+   */
+  public getIdentifyPayload = (email: string) => {
+    if (!this._mounted) return false;
+
+    const validatedEmail = validateEmail(email);
+    if (validatedEmail) {
+      const action = new IdentifyActivity(this._context, {
+        email: validatedEmail,
+      });
+      return action.getTrackPayload();
+    }
   };
 
   /**


### PR DESCRIPTION
Some users have requested the ability to perform their intent tracking server-side to avoid being blocked by ad blockers. This should theoretically be supported by the intent API already, but the API notably expects certain required data in the request payload which is currently only accessible by the intent client itself.

This PR exposes methods on the intent client for getting the fully-qualified request payloads to track `page` and `identify` events. These payloads can then be sent to a proxy server to perform the tracking server-side.