### PR TITLE
Improve storage key naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,12 @@ const TestComponent = () => {
 
 ## Cookies
 
-**NOTE**: This section only applies to intent client versions `1.4.0` and up. If you install the intent client with the website tag, you automatically get access to the latest client version. Versions older than this use obfuscated cookie names and if you need to access them you can reach out
+**NOTE**: This section only applies to intent client versions `1.4.0` and up. If you install the intent client with the website tag, you automatically get access to the latest client version. Versions older than this use obfuscated cookie names. If for some reason you need access to these then you can reach out to the Unify team for support.
 
 When the intent client mounts, it places two values in the user's cookies:
 
 - `unify_visitor_id` - A randomly generated UUID which uniquely identifies the user. This persists across sessions.
-- `unify_session_id` - A randomly generated UUID which uniquely identifies the user's session. Sessions will continue as long as a new page or event is tracked at least once every 30 minutes.
+- `unify_session_id` - A randomly generated UUID which uniquely identifies the user's current session. Sessions will persist as long as a new `page`, `identify`, or `track` event is fired at least once every 30 minutes. This duration be customized with the `sessionDurationMinutes` option on the `UnifyIntentClientConfig`.
 
 These cookies are _first-party cookies_ and associated with the top-level domain where the intent client is running. For example, if the intent client is running on [https://www.unifygtm.com](https://www.unifygtm.com) then the cookies will be associated with `.unifygtm.com`. This means that they are accessible and reused across all subdomains of the top-level domain. In this example, if the intent client were also running on [https://app.unifygtm.com](https://app.unifygtm.com) then a visitor ID stored while on the `www` subdomain would be reused on `app` subdomain.
 
@@ -198,3 +198,5 @@ The following configuration options can be passed when initializing the client:
   - **Default**: `true` if the client is installed via the Unify JavaScript tag, `false` if installed via a package manager
 - `autoIdentify` - Tells the client to automatically monitor text and email input elements on the page for changes. When the current user enters a valid email address into an input, the client will log an `identify` event for that email address.
   - **Default**: `true` if the client is installed via the Unify JavaScript tag, `false` if installed via a package manager
+- `sessionDurationMinutes` - Length in minutes that user sessions will persist when no activities are tracked. Activities include `page`, `identify,` and `track` activities.
+  - **Default**: `30`

--- a/README.md
+++ b/README.md
@@ -79,6 +79,19 @@ const TestComponent = () => {
 }
 ```
 
+## Cookies
+
+**NOTE**: This section only applies to intent client versions `1.4.0` and up. If you install the intent client with the website tag, you automatically get access to the latest client version. Versions older than this use obfuscated cookie names and if you need to access them you can reach out
+
+When the intent client mounts, it places two values in the user's cookies:
+
+- `unify_visitor_id` - A randomly generated UUID which uniquely identifies the user. This persists across sessions.
+- `unify_session_id` - A randomly generated UUID which uniquely identifies the user's session. Sessions will continue as long as a new page or event is tracked at least once every 30 minutes.
+
+These cookies are _first-party cookies_ and associated with the top-level domain where the intent client is running. For example, if the intent client is running on [https://www.unifygtm.com](https://www.unifygtm.com) then the cookies will be associated with `.unifygtm.com`. This means that they are accessible and reused across all subdomains of the top-level domain. In this example, if the intent client were also running on [https://app.unifygtm.com](https://app.unifygtm.com) then a visitor ID stored while on the `www` subdomain would be reused on `app` subdomain.
+
+These cookies are stored for the maximum permitted time by Google Chrome of 400 days and updated every time the visitor visits your site. In other words, as long as the same visitor visits your site at least once every 400 days and does not clear their browser cookies, their visitor ID will be reused across sessions. Note that some browsers have default limits lower than 400 days. In these cases, the maximum allowed limit by the browser will be used.
+
 ## Usage
 
 The Unify Intent Client can be used to log user activity across multiple subdomains of the same top-level domain. For example, if a user visits your marketing website at `www.yoursite.com` and then logs into your production web application at `app.yoursite.com`, the activity in both places will be attributed to the same person.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,8 @@ When you include this tag in your HTML, you will immediately be able to access t
 
 This method is typically used to install the client in e.g. frontend application code such as a Single Page App (SPA) (as opposed to on a static marketing website).
 
-NOTE: See [@unifygtm/intent-react](https://www.npmjs.com/package/@unifygtm/intent-react) if you are using React.
+> [!NOTE]
+> See [@unifygtm/intent-react](https://www.npmjs.com/package/@unifygtm/intent-react) if you are using React.
 
 You can install the client package directly using your preferred package manager:
 
@@ -53,7 +54,8 @@ const unify = new UnifyIntentClient(writeKey, config);
 unify.mount();
 ```
 
-NOTE: The `mount` method on the client is used to initialize it once it is in a browser context. If your application uses server side rendering, you should be sure not to call `mount()` until the code is running in a browser context.
+> [!NOTE]
+> The `mount` method on the client is used to initialize it once it is in a browser context. If your application uses server side rendering, you should be sure not to call `mount()` until the code is running in a browser context.
 
 Once the client is initialized and mounted it will be immediately ready for use. See [Usage](#usage) below for how to use the client after installing. If you wish to cleanup the side effects created by initializing the client (e.g. event listeners), you can do so with the `unmount` method. Here is an example of mounting and unmounting the client in React code:
 
@@ -81,7 +83,8 @@ const TestComponent = () => {
 
 ## Cookies
 
-**NOTE**: This section only applies to intent client versions `1.4.0` and up. If you install the intent client with the website tag, you automatically get access to the latest client version. Versions older than this use obfuscated cookie names. If for some reason you need access to these then you can reach out to the Unify team for support.
+> [!NOTE]
+> This section only applies to intent client versions `1.4.0` and up. If you install the intent client with the website tag, you automatically get access to the latest client version. Versions older than this use obfuscated cookie names. If for some reason you need access to these then you can reach out to the Unify team for support.
 
 When the intent client mounts, it places two values in the user's cookies:
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "build:browser:s3:staging": "pnpm build:browser && aws s3 cp ./dist/js/browser/index.min.js s3://unifygtm-public/tag/v1/script-staging.js",
     "build:browser:s3:testing": "pnpm build:browser && aws s3 cp ./dist/js/browser/index.min.js s3://unifygtm-public/tag/v1/script-testing.js",
     "generate": "pnpm openapi-typescript '../unify/api/tsp-output/@typespec/openapi3/openapi.UnifyAnalyticsApi.yaml' -o './src/spec.ts'",
-    "test": "pnpm jest unit.test"
+    "test": "pnpm jest unit.test",
+    "serve": "http-server . -a localhost -p 3001 -o /test.html"
   },
   "packageManager": "pnpm@9.4.0",
   "devDependencies": {
@@ -45,6 +46,7 @@
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^29.7.0",
     "esbuild": "^0.17.19",
+    "http-server": "^14.1.1",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
     "jest-localstorage-mock": "^2.4.26",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unifygtm/intent-client",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "JavaScript client for interacting with the Unify Intent API in the browser.",
   "keywords": [
     "unify",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,9 @@ importers:
       esbuild:
         specifier: ^0.17.19
         version: 0.17.19
+      http-server:
+        specifier: ^14.1.1
+        version: 14.1.1
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@18.19.39)
@@ -1216,6 +1219,9 @@ packages:
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
 
+  async@3.2.6:
+    resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
+
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
@@ -1267,6 +1273,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  basic-auth@2.0.1:
+    resolution: {integrity: sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==}
+    engines: {node: '>= 0.8'}
+
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
     engines: {node: '>=8'}
@@ -1292,6 +1302,14 @@ packages:
 
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
+
+  call-bind-apply-helpers@1.0.2:
+    resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
+    engines: {node: '>= 0.4'}
+
+  call-bound@1.0.4:
+    resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
+    engines: {node: '>= 0.4'}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -1372,6 +1390,10 @@ packages:
   core-js-compat@3.37.1:
     resolution: {integrity: sha512-9TNiImhKvQqSUkOvk/mMRZzOANTiEVC7WaBNhHcKM7x+/5E1l5NvsysR19zuDQScE8k+kfQXWRN3AtS/eOSHpg==}
 
+  corser@2.0.1:
+    resolution: {integrity: sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==}
+    engines: {node: '>= 0.4.0'}
+
   create-jest@29.7.0:
     resolution: {integrity: sha512-Adz2bdH0Vq3F53KEMJOoftQFutWCukm6J24wbPWRO4k1kMY7gS7ds/uoJkNuV8wDCtWWnuwGcJwpWcih+zEW1Q==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -1397,6 +1419,15 @@ packages:
 
   debug@4.3.5:
     resolution: {integrity: sha512-pt0bNEmneDIvdL1Xsd9oDQ/wrQRkXDT4AUWlNZNPKvW5x/jyO9VFXkJUP07vQ2upmw5PlaITaPKc31jK13V+jg==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.4.1:
+    resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -1436,6 +1467,10 @@ packages:
     engines: {node: '>=12'}
     deprecated: Use your platform's native DOMException instead
 
+  dunder-proto@1.0.1:
+    resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
+    engines: {node: '>= 0.4'}
+
   electron-to-chromium@1.4.815:
     resolution: {integrity: sha512-OvpTT2ItpOXJL7IGcYakRjHCt8L5GrrN/wHCQsRB4PQa1X9fe+X9oen245mIId7s14xvArCGSTIq644yPUKKLg==}
 
@@ -1452,6 +1487,18 @@ packages:
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+
+  es-define-property@1.0.1:
+    resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-object-atoms@1.1.1:
+    resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.17.19:
     resolution: {integrity: sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==}
@@ -1493,6 +1540,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
     engines: {node: '>=10'}
@@ -1526,6 +1576,15 @@ packages:
     resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
     engines: {node: '>=8'}
 
+  follow-redirects@1.15.11:
+    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+
   form-data@4.0.0:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
     engines: {node: '>= 6'}
@@ -1552,9 +1611,17 @@ packages:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
 
+  get-intrinsic@1.3.0:
+    resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
+    engines: {node: '>= 0.4'}
+
   get-package-type@0.1.0:
     resolution: {integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==}
     engines: {node: '>=8.0.0'}
+
+  get-proto@1.0.1:
+    resolution: {integrity: sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==}
+    engines: {node: '>= 0.4'}
 
   get-stream@6.0.1:
     resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
@@ -1575,6 +1642,10 @@ packages:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
     engines: {node: '>=4'}
 
+  gopd@1.2.0:
+    resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
+    engines: {node: '>= 0.4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -1586,9 +1657,17 @@ packages:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
 
+  has-symbols@1.1.0:
+    resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
+    engines: {node: '>= 0.4'}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  he@1.2.0:
+    resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
+    hasBin: true
 
   html-encoding-sniffer@3.0.0:
     resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
@@ -1600,6 +1679,15 @@ packages:
   http-proxy-agent@5.0.0:
     resolution: {integrity: sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==}
     engines: {node: '>= 6'}
+
+  http-proxy@1.18.1:
+    resolution: {integrity: sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==}
+    engines: {node: '>=8.0.0'}
+
+  http-server@14.1.1:
+    resolution: {integrity: sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==}
+    engines: {node: '>=12'}
+    hasBin: true
 
   https-proxy-agent@5.0.1:
     resolution: {integrity: sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==}
@@ -1924,6 +2012,10 @@ packages:
   makeerror@1.0.12:
     resolution: {integrity: sha512-JmqCvUhmt43madlpFzG4BQzG2Z3m6tvQDNKdClZnO3VbIudJYmxsT0FNJMeiB2+JTSlTQTSbU8QdesVmwJcmLg==}
 
+  math-intrinsics@1.1.0:
+    resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
+    engines: {node: '>= 0.4'}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -1943,6 +2035,11 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
@@ -1950,8 +2047,14 @@ packages:
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -1973,6 +2076,10 @@ packages:
   nwsapi@2.2.10:
     resolution: {integrity: sha512-QK0sRs7MKv0tKe1+5uZIQk/C8XGza4DAnztJG8iD+TpJIORARrCxczA738awHrZoHeTjSSoHqao2teO0dC/gFQ==}
 
+  object-inspect@1.13.4:
+    resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
+    engines: {node: '>= 0.4'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -1982,6 +2089,10 @@ packages:
 
   openapi-typescript@6.7.6:
     resolution: {integrity: sha512-c/hfooPx+RBIOPM09GSxABOZhYPblDoyaGhqBkD/59vtpN21jEuWKDlM0KYTvqJVlSYjKs0tBcIdeXKChlSPtw==}
+    hasBin: true
+
+  opener@1.5.2:
+    resolution: {integrity: sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==}
     hasBin: true
 
   p-limit@2.3.0:
@@ -2041,6 +2152,10 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
+  portfinder@1.0.37:
+    resolution: {integrity: sha512-yuGIEjDAYnnOex9ddMnKZEMFE0CcGo6zbfzDklkmT1m5z734ss6JMzN9rNB3+RR7iS+F10D4/BVIaXOyh8PQKw==}
+    engines: {node: '>= 10.12'}
+
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
@@ -2063,6 +2178,10 @@ packages:
 
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  qs@6.14.0:
+    resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
+    engines: {node: '>=0.6'}
 
   querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
@@ -2131,12 +2250,18 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
+  safe-buffer@5.1.2:
+    resolution: {integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   saxes@6.0.0:
     resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
     engines: {node: '>=v12.22.7'}
+
+  secure-compare@3.0.1:
+    resolution: {integrity: sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==}
 
   semver@5.7.2:
     resolution: {integrity: sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==}
@@ -2158,6 +2283,22 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  side-channel-list@1.0.0:
+    resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-map@1.0.1:
+    resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
+    engines: {node: '>= 0.4'}
+
+  side-channel-weakmap@1.0.2:
+    resolution: {integrity: sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.0:
+    resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
 
   signal-exit@3.0.7:
     resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
@@ -2330,6 +2471,10 @@ packages:
     resolution: {integrity: sha512-6t3foTQI9qne+OZoVQB/8x8rk2k1eVy1gRXhV3oFQ5T6R1dqQ1xtin3XqSlx3+ATBkliTaR/hHyJBm+LVPNM8w==}
     engines: {node: '>=4'}
 
+  union@0.5.0:
+    resolution: {integrity: sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==}
+    engines: {node: '>= 0.8.0'}
+
   universalify@0.2.0:
     resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
     engines: {node: '>= 4.0.0'}
@@ -2339,6 +2484,9 @@ packages:
     hasBin: true
     peerDependencies:
       browserslist: '>= 4.21.0'
+
+  url-join@4.0.1:
+    resolution: {integrity: sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==}
 
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
@@ -3725,6 +3873,8 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  async@3.2.6: {}
+
   asynckit@0.4.0: {}
 
   babel-core@7.0.0-bridge.0(@babel/core@7.24.7):
@@ -3809,6 +3959,10 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  basic-auth@2.0.1:
+    dependencies:
+      safe-buffer: 5.1.2
+
   binary-extensions@2.3.0:
     optional: true
 
@@ -3837,6 +3991,16 @@ snapshots:
       node-int64: 0.4.0
 
   buffer-from@1.1.2: {}
+
+  call-bind-apply-helpers@1.0.2:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+
+  call-bound@1.0.4:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
 
@@ -3912,6 +4076,8 @@ snapshots:
     dependencies:
       browserslist: 4.23.1
 
+  corser@2.0.1: {}
+
   create-jest@29.7.0(@types/node@18.19.39):
     dependencies:
       '@jest/types': 29.6.3
@@ -3951,6 +4117,10 @@ snapshots:
     dependencies:
       ms: 2.1.2
 
+  debug@4.4.1:
+    dependencies:
+      ms: 2.1.3
+
   decimal.js@10.4.3: {}
 
   dedent@1.5.3: {}
@@ -3967,6 +4137,12 @@ snapshots:
     dependencies:
       webidl-conversions: 7.0.0
 
+  dunder-proto@1.0.1:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-errors: 1.3.0
+      gopd: 1.2.0
+
   electron-to-chromium@1.4.815: {}
 
   emittery@0.13.1: {}
@@ -3978,6 +4154,14 @@ snapshots:
   error-ex@1.3.2:
     dependencies:
       is-arrayish: 0.2.1
+
+  es-define-property@1.0.1: {}
+
+  es-errors@1.3.0: {}
+
+  es-object-atoms@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
 
   esbuild@0.17.19:
     optionalDependencies:
@@ -4050,6 +4234,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@4.0.7: {}
+
   execa@5.1.1:
     dependencies:
       cross-spawn: 7.0.6
@@ -4099,6 +4285,8 @@ snapshots:
       locate-path: 5.0.0
       path-exists: 4.0.0
 
+  follow-redirects@1.15.11: {}
+
   form-data@4.0.0:
     dependencies:
       asynckit: 0.4.0
@@ -4118,7 +4306,25 @@ snapshots:
 
   get-caller-file@2.0.5: {}
 
+  get-intrinsic@1.3.0:
+    dependencies:
+      call-bind-apply-helpers: 1.0.2
+      es-define-property: 1.0.1
+      es-errors: 1.3.0
+      es-object-atoms: 1.1.1
+      function-bind: 1.1.2
+      get-proto: 1.0.1
+      gopd: 1.2.0
+      has-symbols: 1.1.0
+      hasown: 2.0.2
+      math-intrinsics: 1.1.0
+
   get-package-type@0.1.0: {}
+
+  get-proto@1.0.1:
+    dependencies:
+      dunder-proto: 1.0.1
+      es-object-atoms: 1.1.1
 
   get-stream@6.0.1: {}
 
@@ -4141,15 +4347,21 @@ snapshots:
 
   globals@11.12.0: {}
 
+  gopd@1.2.0: {}
+
   graceful-fs@4.2.11: {}
 
   has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
 
+  has-symbols@1.1.0: {}
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  he@1.2.0: {}
 
   html-encoding-sniffer@3.0.0:
     dependencies:
@@ -4163,6 +4375,33 @@ snapshots:
       agent-base: 6.0.2
       debug: 4.3.5
     transitivePeerDependencies:
+      - supports-color
+
+  http-proxy@1.18.1:
+    dependencies:
+      eventemitter3: 4.0.7
+      follow-redirects: 1.15.11
+      requires-port: 1.0.0
+    transitivePeerDependencies:
+      - debug
+
+  http-server@14.1.1:
+    dependencies:
+      basic-auth: 2.0.1
+      chalk: 4.1.2
+      corser: 2.0.1
+      he: 1.2.0
+      html-encoding-sniffer: 3.0.0
+      http-proxy: 1.18.1
+      mime: 1.6.0
+      minimist: 1.2.8
+      opener: 1.5.2
+      portfinder: 1.0.37
+      secure-compare: 3.0.1
+      union: 0.5.0
+      url-join: 4.0.1
+    transitivePeerDependencies:
+      - debug
       - supports-color
 
   https-proxy-agent@5.0.1:
@@ -4682,6 +4921,8 @@ snapshots:
     dependencies:
       tmpl: 1.0.5
 
+  math-intrinsics@1.1.0: {}
+
   merge-stream@2.0.0: {}
 
   merge2@1.4.1: {}
@@ -4697,13 +4938,19 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  mime@1.6.0: {}
+
   mimic-fn@2.1.0: {}
 
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.11
 
+  minimist@1.2.8: {}
+
   ms@2.1.2: {}
+
+  ms@2.1.3: {}
 
   natural-compare@1.4.0: {}
 
@@ -4718,6 +4965,8 @@ snapshots:
       path-key: 3.1.1
 
   nwsapi@2.2.10: {}
+
+  object-inspect@1.13.4: {}
 
   once@1.4.0:
     dependencies:
@@ -4735,6 +4984,8 @@ snapshots:
       supports-color: 9.4.0
       undici: 5.28.4
       yargs-parser: 21.1.1
+
+  opener@1.5.2: {}
 
   p-limit@2.3.0:
     dependencies:
@@ -4781,6 +5032,13 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
+  portfinder@1.0.37:
+    dependencies:
+      async: 3.2.6
+      debug: 4.4.1
+    transitivePeerDependencies:
+      - supports-color
+
   prettier@2.8.8: {}
 
   pretty-format@29.7.0:
@@ -4799,6 +5057,10 @@ snapshots:
   punycode@2.3.1: {}
 
   pure-rand@6.1.0: {}
+
+  qs@6.14.0:
+    dependencies:
+      side-channel: 1.1.0
 
   querystringify@2.2.0: {}
 
@@ -4862,11 +5124,15 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
+  safe-buffer@5.1.2: {}
+
   safer-buffer@2.1.2: {}
 
   saxes@6.0.0:
     dependencies:
       xmlchars: 2.2.0
+
+  secure-compare@3.0.1: {}
 
   semver@5.7.2: {}
 
@@ -4879,6 +5145,34 @@ snapshots:
       shebang-regex: 3.0.0
 
   shebang-regex@3.0.0: {}
+
+  side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-map@1.0.1:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-weakmap@1.0.2:
+    dependencies:
+      call-bound: 1.0.4
+      es-errors: 1.3.0
+      get-intrinsic: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-map: 1.0.1
+
+  side-channel@1.1.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.0
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
 
   signal-exit@3.0.7: {}
 
@@ -5018,6 +5312,10 @@ snapshots:
 
   unicode-property-aliases-ecmascript@2.1.0: {}
 
+  union@0.5.0:
+    dependencies:
+      qs: 6.14.0
+
   universalify@0.2.0: {}
 
   update-browserslist-db@1.0.16(browserslist@4.23.1):
@@ -5025,6 +5323,8 @@ snapshots:
       browserslist: 4.23.1
       escalade: 3.1.2
       picocolors: 1.0.1
+
+  url-join@4.0.1: {}
 
   url-parse@1.5.10:
     dependencies:

--- a/src/client/activities/activity.ts
+++ b/src/client/activities/activity.ts
@@ -62,8 +62,7 @@ abstract class Activity<TActivityData extends object> {
    */
   private getBaseActivityPayload = (): AnalyticsEventBase => ({
     type: this.getActivityType(),
-    anonymousUserId:
-      this._intentContext.identityManager.getOrCreateAnonymousUserId(),
+    anonymousUserId: this._intentContext.identityManager.getOrCreateVisitorId(),
     sessionId:
       this._intentContext.sessionManager.getOrCreateSession().sessionId,
     context: getActivityContext(),

--- a/src/client/constants.ts
+++ b/src/client/constants.ts
@@ -1,1 +1,3 @@
 export const UNIFY_INTENT_V1_URL = 'https://unifyintent.com/analytics/api/v1';
+
+export const DEFAULT_SESSION_MINUTES_TO_EXPIRE = 30;

--- a/src/client/managers/identity.ts
+++ b/src/client/managers/identity.ts
@@ -3,14 +3,14 @@ import { v4 as uuidv4 } from 'uuid';
 import { CookieStorageService } from '../storage';
 
 /**
- * @deprecated Prefer `ANONYMOUS_USER_ID_STORAGE_KEY` instead
+ * @deprecated Prefer `VISITOR_ID_STORAGE_KEY` instead
  */
-export const LEGACY_ANONYMOUS_USER_ID_STORAGE_KEY = 'anonymousUserId';
+export const LEGACY_VISITOR_ID_STORAGE_KEY = 'anonymousUserId';
 
 /**
- * The name of the cookie used to store the current user's anonymous user ID.
+ * The name of the cookie used to store the current visitor ID.
  */
-export const ANONYMOUS_USER_ID_STORAGE_KEY = 'unify_user_id';
+export const VISITOR_ID_STORAGE_KEY = 'unify_visitor_id';
 
 /**
  * This class is used to store and manage user identity information
@@ -19,69 +19,64 @@ export const ANONYMOUS_USER_ID_STORAGE_KEY = 'unify_user_id';
 export class IdentityManager {
   private readonly _storageService: CookieStorageService;
 
-  private _anonymousUserId: string | null;
+  private _visitorId: string | null;
 
   constructor(writeKey: string) {
     this._storageService = new CookieStorageService(writeKey);
-    this._anonymousUserId = null;
+    this._visitorId = null;
   }
 
   /**
-   * Gets an anonymous user ID for the current user if one exists,
+   * Gets a visitor ID for the current user if one exists,
    * otherwise creates one for them.
    *
-   * @returns the anonymous user ID, a randomly generated UUID
+   * @returns the visitor ID, a randomly generated UUID
    */
-  public getOrCreateAnonymousUserId = (): string => {
-    if (this._anonymousUserId) {
-      return this._anonymousUserId;
+  public getOrCreateVisitorId = (): string => {
+    if (this._visitorId) {
+      return this._visitorId;
     }
 
-    const anonymousUserId =
-      this.getAnonymousUserId() || this.createAnonymousUserId();
-    this._anonymousUserId = anonymousUserId;
+    const visitorId = this.getVisitorId() || this.createVisitorId();
+    this._visitorId = visitorId;
 
-    return anonymousUserId;
+    return visitorId;
   };
 
   /**
-   * Gets the current user's anonymous user ID from cookies if
-   * one exists.
+   * Gets the current visitor ID from cookies if one exists.
    *
-   * @returns the anonymous user ID if it exists, else `null`
+   * @returns the visitor ID if it exists, else `null`
    */
-  private getAnonymousUserId = (): string | null => {
-    const userId = this._storageService.get<string>(
-      ANONYMOUS_USER_ID_STORAGE_KEY,
-    );
+  private getVisitorId = (): string | null => {
+    const visitorId = this._storageService.get<string>(VISITOR_ID_STORAGE_KEY);
 
-    if (userId) {
-      return userId;
+    if (visitorId) {
+      return visitorId;
     }
 
     // Fall back to legacy key name for values stored by old client versions
-    const legacyUserId = this._storageService.get<string>(
-      LEGACY_ANONYMOUS_USER_ID_STORAGE_KEY,
+    const legacyVisitorId = this._storageService.get<string>(
+      LEGACY_VISITOR_ID_STORAGE_KEY,
     );
 
     // Store using new key so the next time we won't need to fall back
-    if (legacyUserId) {
-      this._storageService.set(ANONYMOUS_USER_ID_STORAGE_KEY, legacyUserId);
+    if (legacyVisitorId) {
+      this._storageService.set(VISITOR_ID_STORAGE_KEY, legacyVisitorId);
     }
 
-    return legacyUserId;
+    return legacyVisitorId;
   };
 
   /**
-   * Creates a randomly generated anonymous user ID and stores it
-   * in cookies.
+   * Creates a randomly generated visitor ID and stores it in cookies.
    *
-   * @returns the newly created and stored anonymous user ID
+   * @returns the newly created and stored visitor ID
    */
-  private createAnonymousUserId = (): string => {
-    const anonymousUserId = uuidv4();
-    this._storageService.set(ANONYMOUS_USER_ID_STORAGE_KEY, anonymousUserId);
+  private createVisitorId = (): string => {
+    const visitorId = uuidv4();
+    this._storageService.set(VISITOR_ID_STORAGE_KEY, visitorId);
 
-    return anonymousUserId;
+    return visitorId;
   };
 }

--- a/src/client/managers/identity.ts
+++ b/src/client/managers/identity.ts
@@ -59,9 +59,17 @@ export class IdentityManager {
       return userId;
     }
 
-    return this._storageService.get<string>(
+    // Fall back to legacy key name for values stored by old client versions
+    const legacyUserId = this._storageService.get<string>(
       LEGACY_ANONYMOUS_USER_ID_STORAGE_KEY,
     );
+
+    // Store using new key so the next time we won't need to fall back
+    if (legacyUserId) {
+      this._storageService.set(ANONYMOUS_USER_ID_STORAGE_KEY, legacyUserId);
+    }
+
+    return legacyUserId;
   };
 
   /**

--- a/src/client/managers/identity.ts
+++ b/src/client/managers/identity.ts
@@ -2,7 +2,15 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { CookieStorageService } from '../storage';
 
-export const ANONYMOUS_USER_ID_STORAGE_KEY = 'anonymousUserId';
+/**
+ * @deprecated Prefer `ANONYMOUS_USER_ID_STORAGE_KEY` instead
+ */
+export const LEGACY_ANONYMOUS_USER_ID_STORAGE_KEY = 'anonymousUserId';
+
+/**
+ * The name of the cookie used to store the current user's anonymous user ID.
+ */
+export const ANONYMOUS_USER_ID_STORAGE_KEY = 'unify_user_id';
 
 /**
  * This class is used to store and manage user identity information
@@ -43,7 +51,17 @@ export class IdentityManager {
    * @returns the anonymous user ID if it exists, else `null`
    */
   private getAnonymousUserId = (): string | null => {
-    return this._storageService.get(ANONYMOUS_USER_ID_STORAGE_KEY);
+    const userId = this._storageService.get<string>(
+      ANONYMOUS_USER_ID_STORAGE_KEY,
+    );
+
+    if (userId) {
+      return userId;
+    }
+
+    return this._storageService.get<string>(
+      LEGACY_ANONYMOUS_USER_ID_STORAGE_KEY,
+    );
   };
 
   /**

--- a/src/client/managers/sessions.ts
+++ b/src/client/managers/sessions.ts
@@ -9,14 +9,14 @@ import {
 } from '../utils/helpers';
 
 /**
- * @deprecated Prefer `SESSION_ID_STORAGE_KEY` instead
+ * @deprecated Prefer `SESSION_STORAGE_KEY` instead
  */
-export const LEGACY_SESSION_ID_STORAGE_KEY = 'clientSession';
+export const LEGACY_SESSION_STORAGE_KEY = 'clientSession';
 
 /**
  * The localStorage key used to track the user's current session ID.
  */
-export const SESSION_ID_STORAGE_KEY = 'unify_session_id';
+export const SESSION_STORAGE_KEY = 'unify_session';
 export const SESSION_MINUTES_TO_EXPIRE = 30;
 
 /**
@@ -116,9 +116,8 @@ export class SessionManager {
    * @returns the stored session object, or `null` if none exists
    */
   private getStoredSession = (): ClientSession | null => {
-    const session = this._storageService.get<ClientSession>(
-      SESSION_ID_STORAGE_KEY,
-    );
+    const session =
+      this._storageService.get<ClientSession>(SESSION_STORAGE_KEY);
 
     if (session) {
       return session;
@@ -126,7 +125,7 @@ export class SessionManager {
 
     // Fall back to legacy key name for values stored by old client versions
     const legacySession = this._storageService.get<ClientSession>(
-      LEGACY_SESSION_ID_STORAGE_KEY,
+      LEGACY_SESSION_STORAGE_KEY,
     );
 
     // Store using new key so the next time we won't need to fall back
@@ -143,6 +142,6 @@ export class SessionManager {
    * @param session - the session to store
    */
   private setStoredSession = (session: ClientSession): void => {
-    this._storageService.set(SESSION_ID_STORAGE_KEY, session);
+    this._storageService.set(SESSION_STORAGE_KEY, session);
   };
 }

--- a/src/client/managers/sessions.ts
+++ b/src/client/managers/sessions.ts
@@ -1,7 +1,7 @@
 import { v4 as uuidv4 } from 'uuid';
 
 import { ClientSession } from '../../types';
-import { LocalStorageService } from '../storage';
+import { CookieStorageService, LocalStorageService } from '../storage';
 import {
   getCurrentPageProperties,
   getCurrentUserAgentData,
@@ -14,10 +14,15 @@ import {
 export const LEGACY_SESSION_STORAGE_KEY = 'clientSession';
 
 /**
- * The localStorage key used to track the user's current session ID.
+ * The local storage key used to track the user's current session ID.
  */
 export const SESSION_STORAGE_KEY = 'unify_session';
 export const SESSION_MINUTES_TO_EXPIRE = 30;
+
+/**
+ * The key used to store the current session ID in cookies.
+ */
+export const SESSION_ID_STORAGE_KEY = 'unify_session_id';
 
 /**
  * This class is used to store and manage user session data in
@@ -26,12 +31,14 @@ export const SESSION_MINUTES_TO_EXPIRE = 30;
 export class SessionManager {
   private readonly _writeKey: string;
   private readonly _storageService: LocalStorageService;
+  private readonly _cookieStorageService: CookieStorageService;
 
   private _currentSession: ClientSession | null;
 
   constructor(writeKey: string) {
     this._writeKey = writeKey;
     this._storageService = new LocalStorageService(this._writeKey);
+    this._cookieStorageService = new CookieStorageService(this._writeKey);
     this._currentSession = null;
   }
 
@@ -137,11 +144,12 @@ export class SessionManager {
   };
 
   /**
-   * Stores a session object in local storage.
+   * Stores a session object in local storage and updates the ID
    *
    * @param session - the session to store
    */
   private setStoredSession = (session: ClientSession): void => {
     this._storageService.set(SESSION_STORAGE_KEY, session);
+    this._cookieStorageService.set(SESSION_ID_STORAGE_KEY, session.sessionId);
   };
 }

--- a/src/client/managers/sessions.ts
+++ b/src/client/managers/sessions.ts
@@ -124,9 +124,17 @@ export class SessionManager {
       return session;
     }
 
-    return this._storageService.get<ClientSession>(
+    // Fall back to legacy key name for values stored by old client versions
+    const legacySession = this._storageService.get<ClientSession>(
       LEGACY_SESSION_ID_STORAGE_KEY,
     );
+
+    // Store using new key so the next time we won't need to fall back
+    if (legacySession) {
+      this.setStoredSession(legacySession);
+    }
+
+    return legacySession;
   };
 
   /**

--- a/src/client/managers/sessions.ts
+++ b/src/client/managers/sessions.ts
@@ -8,7 +8,15 @@ import {
   getTimeForMinutesInFuture,
 } from '../utils/helpers';
 
-export const CLIENT_SESSION_STORAGE_KEY = 'clientSession';
+/**
+ * @deprecated Prefer `SESSION_ID_STORAGE_KEY` instead
+ */
+export const LEGACY_SESSION_ID_STORAGE_KEY = 'clientSession';
+
+/**
+ * The localStorage key used to track the user's current session ID.
+ */
+export const SESSION_ID_STORAGE_KEY = 'unify_session_id';
 export const SESSION_MINUTES_TO_EXPIRE = 30;
 
 /**
@@ -108,7 +116,17 @@ export class SessionManager {
    * @returns the stored session object, or `null` if none exists
    */
   private getStoredSession = (): ClientSession | null => {
-    return this._storageService.get<ClientSession>(CLIENT_SESSION_STORAGE_KEY);
+    const session = this._storageService.get<ClientSession>(
+      SESSION_ID_STORAGE_KEY,
+    );
+
+    if (session) {
+      return session;
+    }
+
+    return this._storageService.get<ClientSession>(
+      LEGACY_SESSION_ID_STORAGE_KEY,
+    );
   };
 
   /**
@@ -117,6 +135,6 @@ export class SessionManager {
    * @param session - the session to store
    */
   private setStoredSession = (session: ClientSession): void => {
-    this._storageService.set(CLIENT_SESSION_STORAGE_KEY, session);
+    this._storageService.set(SESSION_ID_STORAGE_KEY, session);
   };
 }

--- a/src/client/storage/cookies.ts
+++ b/src/client/storage/cookies.ts
@@ -14,36 +14,19 @@ export class CookieStorageService extends StorageService {
    * @returns the encoded value from cookies if it exists, otherwise `null`
    */
   protected retrieveValue(key: string): string | null {
-    const value = Cookies.get(key) ?? null;
-
-    // We used to set cookies on a specific subdomain, but to enable
-    // re-using cookies across subdomains we deprecated this in favor
-    // of setting cookies at the top-level domain only. This call to
-    // `remove` will temporarily be used to remove old cookies stored
-    // at the subdomain level in favor of storing them at the TLD.
-    //
-    // TODO(Solomon): Remove this after a few months have passed
-    if (value) {
-      // Remove subdomain-specific cookie
-      Cookies.remove(key);
-
-      // Store same cookie at top-level domain
-      this.storeValue(key, value);
-    }
-
-    return value;
+    return Cookies.get(key) ?? null;
   }
 
   /**
-   * Stores an encoded value associated with a given key in cookies.
+   * Stores a value associated with a given key in cookies.
    * This cookie can be shared across subdomains of the current
    * top-level domain.
    *
    * @param key - the key associated with the value to store
-   * @param encodedValue - the encoded value to store
+   * @param value - the value to store
    */
-  protected storeValue(key: string, encodedValue: string): void {
-    Cookies.set(key, encodedValue, {
+  protected storeValue(key: string, value: string): void {
+    Cookies.set(key, value, {
       domain: `.${getCurrentTopLevelDomain()}`,
       expires: 365,
     });

--- a/src/client/storage/cookies.ts
+++ b/src/client/storage/cookies.ts
@@ -14,7 +14,14 @@ export class CookieStorageService extends StorageService {
    * @returns the encoded value from cookies if it exists, otherwise `null`
    */
   protected retrieveValue(key: string): string | null {
-    return Cookies.get(key) ?? null;
+    const value = Cookies.get(key) ?? null;
+
+    // Reset the cookie expiration
+    if (value) {
+      this.storeValue(key, value);
+    }
+
+    return value;
   }
 
   /**
@@ -28,7 +35,7 @@ export class CookieStorageService extends StorageService {
   protected storeValue(key: string, value: string): void {
     Cookies.set(key, value, {
       domain: `.${getCurrentTopLevelDomain()}`,
-      expires: 365,
+      expires: 400,
     });
   }
 }

--- a/src/client/storage/storage.ts
+++ b/src/client/storage/storage.ts
@@ -35,6 +35,25 @@ abstract class StorageService {
    * @returns the value from storage if it exists, otherwise `null`
    */
   public get = <T>(key: string): T | null => {
+    const jsonValue = this.retrieveValue(key);
+    if (jsonValue) {
+      return JSON.parse(jsonValue) as T;
+    }
+
+    // Fall back to legacy get from storage for older client versions
+    return this.legacyGet(key);
+  };
+
+  /**
+   * @deprecated Legacy function to retrieve the value for a key from
+   * the underlying storage service. This cannot be removed to maintain
+   * backwards compatibility with older versions of the intent client.
+   * Versions `1.3.0` and older will depend on this.
+   *
+   * @param key - the key associated with the value to get
+   * @returns the value from storage if it exists, otherwise `null`
+   */
+  private legacyGet = <T>(key: string): T | null => {
     const encodedValue = this.retrieveValue(this.buildKey(key));
     if (encodedValue) {
       return decodeFromStorage(encodedValue);
@@ -51,10 +70,13 @@ abstract class StorageService {
    * @param value - the value to store
    */
   public set = <T>(key: string, value: T): void => {
-    this.storeValue(this.buildKey(key), encodeForStorage(value));
+    this.storeValue(key, JSON.stringify(value));
   };
 
   /**
+   * @deprecated The intent client no longer encodes keys and values for
+   * storage and instead stores them directly.
+   *
    * Generates a unique key using the public Unify API key for
    * storing a value in the underlying storage service.
    *

--- a/src/client/storage/storage.ts
+++ b/src/client/storage/storage.ts
@@ -1,4 +1,4 @@
-import { decodeFromStorage, encodeForStorage } from './utils';
+import { decodeFromStorage, encodeForStorage, safeParse } from './utils';
 
 /**
  * Abstract class for storing generic key/value pairs in a storage service.
@@ -37,11 +37,10 @@ abstract class StorageService {
   public get = <T>(key: string): T | null => {
     const jsonValue = this.retrieveValue(key);
     if (jsonValue) {
-      return JSON.parse(jsonValue) as T;
+      return safeParse(jsonValue) as T;
     }
 
-    // Fall back to legacy get from storage for older client versions
-    return this.legacyGet(key);
+    return this.legacyGet<T>(key);
   };
 
   /**
@@ -70,7 +69,10 @@ abstract class StorageService {
    * @param value - the value to store
    */
   public set = <T>(key: string, value: T): void => {
-    this.storeValue(key, JSON.stringify(value));
+    this.storeValue(
+      key,
+      typeof value === 'string' ? value : JSON.stringify(value),
+    );
   };
 
   /**

--- a/src/client/storage/storage.ts
+++ b/src/client/storage/storage.ts
@@ -73,6 +73,21 @@ abstract class StorageService {
       key,
       typeof value === 'string' ? value : JSON.stringify(value),
     );
+
+    // Maintain backwards compatibility
+    this.legacySet(key, value);
+  };
+
+  /**
+   * @deprecated Legacy function to store a value in the underlying storage service.
+   * This cannot be removed to maintain backwards compatibility with older versions
+   * of the intent client. Versions `1.3.0` and older will depend on this.
+   *
+   * @param key - the key to associate with the value to be stored
+   * @param value - the value to store
+   */
+  private legacySet = <T>(key: string, value: T): void => {
+    this.storeValue(this.buildKey(key), encodeForStorage(value));
   };
 
   /**

--- a/src/client/storage/utils.ts
+++ b/src/client/storage/utils.ts
@@ -3,6 +3,20 @@ import { decode, encode } from 'js-base64';
 const TEST_STORAGE_VALUE = 'test';
 
 /**
+ * Helper function to parse a value from storage as either JSON or a string.
+ *
+ * @param value the value to parse
+ * @returns the safely parsed value
+ */
+export function safeParse<T = unknown>(value: string): T | string {
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+/**
  * @deprecated The intent client no longer encodes keys and values for
  * storage and instead stores them directly.
  *
@@ -25,7 +39,7 @@ export function encodeForStorage<T>(value: T): string {
  * @returns the decoded value
  */
 export function decodeFromStorage<T>(encodedValue: string): T {
-  return JSON.parse(decode(encodedValue)) as T;
+  return safeParse(decode(encodedValue)) as T;
 }
 
 /**

--- a/src/client/storage/utils.ts
+++ b/src/client/storage/utils.ts
@@ -3,6 +3,9 @@ import { decode, encode } from 'js-base64';
 const TEST_STORAGE_VALUE = 'test';
 
 /**
+ * @deprecated The intent client no longer encodes keys and values for
+ * storage and instead stores them directly.
+ *
  * Encodes an arbitrary value to base-64 encoding for storage.
  *
  * @param value - the value to encode, can be a string, object, etc.
@@ -13,6 +16,9 @@ export function encodeForStorage<T>(value: T): string {
 }
 
 /**
+ * @deprecated The intent client no longer encodes keys and values for
+ * storage and instead stores them directly.
+ *
  * Decodes an encoded value which has been retrieved from storage.
  *
  * @param encodedValue - the value to decode

--- a/src/client/unify-intent-client.ts
+++ b/src/client/unify-intent-client.ts
@@ -9,6 +9,7 @@ import UnifyApiClient from './unify-api-client';
 import { UnifyIntentAgent } from './agent';
 import { isIntentClient, validateEmail } from './utils/helpers';
 import { logUnifyError } from './utils/logging';
+import { DEFAULT_SESSION_MINUTES_TO_EXPIRE } from './constants';
 
 declare global {
   interface Window {
@@ -20,6 +21,7 @@ declare global {
 export const DEFAULT_UNIFY_INTENT_CLIENT_CONFIG: UnifyIntentClientConfig = {
   autoPage: false,
   autoIdentify: false,
+  sessionDurationMinutes: DEFAULT_SESSION_MINUTES_TO_EXPIRE,
 };
 
 /**
@@ -64,7 +66,9 @@ export default class UnifyIntentClient {
     const apiClient = new UnifyApiClient(this._writeKey);
 
     // Initialize user session
-    const sessionManager = new SessionManager(this._writeKey);
+    const sessionManager = new SessionManager(this._writeKey, {
+      durationMinutes: this._config.sessionDurationMinutes,
+    });
     sessionManager.getOrCreateSession();
 
     // Create visitor ID if needed

--- a/src/client/unify-intent-client.ts
+++ b/src/client/unify-intent-client.ts
@@ -67,7 +67,7 @@ export default class UnifyIntentClient {
     const sessionManager = new SessionManager(this._writeKey);
     sessionManager.getOrCreateSession();
 
-    // Create anonymous user ID if needed
+    // Create visitor ID if needed
     const identityManager = new IdentityManager(this._writeKey);
     identityManager.getOrCreateVisitorId();
 

--- a/src/client/unify-intent-client.ts
+++ b/src/client/unify-intent-client.ts
@@ -69,7 +69,7 @@ export default class UnifyIntentClient {
 
     // Create anonymous user ID if needed
     const identityManager = new IdentityManager(this._writeKey);
-    identityManager.getOrCreateAnonymousUserId();
+    identityManager.getOrCreateVisitorId();
 
     // Initialize context
     this._context = {

--- a/src/tests/client/activities/identify.unit.test.ts
+++ b/src/tests/client/activities/identify.unit.test.ts
@@ -5,7 +5,7 @@ import {
   UNIFY_INTENT_IDENTIFY_URL,
 } from '../../../client/activities';
 import { IdentifyEventData } from '../../../types';
-import { MockClientSession, TEST_ANONYMOUS_USER_ID } from '../../mocks/data';
+import { MockClientSession, TEST_VISITOR_ID } from '../../mocks/data';
 import { MockUnifyIntentContext } from '../../mocks/intent-context-mock';
 
 describe('IdentifyActivity', () => {
@@ -22,8 +22,8 @@ describe('IdentifyActivity', () => {
       mockContext.sessionManager.getOrCreateSession.mockReturnValue(
         MockClientSession(),
       );
-      mockContext.identityManager.getOrCreateAnonymousUserId.mockReturnValue(
-        TEST_ANONYMOUS_USER_ID,
+      mockContext.identityManager.getOrCreateVisitorId.mockReturnValue(
+        TEST_VISITOR_ID,
       );
     });
 

--- a/src/tests/client/activities/page.unit.test.ts
+++ b/src/tests/client/activities/page.unit.test.ts
@@ -5,7 +5,7 @@ import {
   UNIFY_INTENT_PAGE_URL,
 } from '../../../client/activities';
 import { PageEventData } from '../../../types';
-import { MockClientSession, TEST_ANONYMOUS_USER_ID } from '../../mocks/data';
+import { MockClientSession, TEST_VISITOR_ID } from '../../mocks/data';
 import { MockUnifyIntentContext } from '../../mocks/intent-context-mock';
 
 describe('PageActivity', () => {
@@ -22,8 +22,8 @@ describe('PageActivity', () => {
       mockContext.sessionManager.getOrCreateSession.mockReturnValue(
         MockClientSession(),
       );
-      mockContext.identityManager.getOrCreateAnonymousUserId.mockReturnValue(
-        TEST_ANONYMOUS_USER_ID,
+      mockContext.identityManager.getOrCreateVisitorId.mockReturnValue(
+        TEST_VISITOR_ID,
       );
     });
 

--- a/src/tests/client/agent/unify-intent-agent.unit.test.ts
+++ b/src/tests/client/agent/unify-intent-agent.unit.test.ts
@@ -445,7 +445,7 @@ describe('UnifyIntentAgent', () => {
           expect(mockedIdentifyActivity.track).toHaveBeenCalledTimes(1);
           expect(agent.__getSubmittedEmails().size).toEqual(1);
           expect(
-            agent.__getSubmittedEmails().entries().next().value[0],
+            agent.__getSubmittedEmails().entries().next().value?.[0],
           ).toEqual('solomon-form@unifygtm.com');
         });
 
@@ -467,7 +467,7 @@ describe('UnifyIntentAgent', () => {
           expect(mockedIdentifyActivity.track).toHaveBeenCalledTimes(1);
           expect(agent.__getSubmittedEmails().size).toEqual(1);
           expect(
-            agent.__getSubmittedEmails().entries().next().value[0],
+            agent.__getSubmittedEmails().entries().next().value?.[0],
           ).toEqual('solomon-enrichment@unifygtm.com');
         });
 
@@ -504,7 +504,7 @@ describe('UnifyIntentAgent', () => {
             expect(mockedIdentifyActivity.track).toHaveBeenCalledTimes(1);
             expect(agent.__getSubmittedEmails().size).toEqual(1);
             expect(
-              agent.__getSubmittedEmails().entries().next().value[0],
+              agent.__getSubmittedEmails().entries().next().value?.[0],
             ).toEqual('solomon@unifygtm.com');
           });
 

--- a/src/tests/client/managers/identity.unit.test.ts
+++ b/src/tests/client/managers/identity.unit.test.ts
@@ -1,8 +1,9 @@
 import { anyString, mock, mockReset } from 'jest-mock-extended';
 
 import {
-  ANONYMOUS_USER_ID_STORAGE_KEY,
+  LEGACY_ANONYMOUS_USER_ID_STORAGE_KEY,
   IdentityManager,
+  ANONYMOUS_USER_ID_STORAGE_KEY,
 } from '../../../client/managers';
 import { CookieStorageService } from '../../../client/storage';
 import { TEST_ANONYMOUS_USER_ID, TEST_WRITE_KEY } from '../../mocks/data';
@@ -26,6 +27,9 @@ describe('IdentityManager', () => {
       expect(cookieStorageMock.get).toHaveBeenCalledWith(
         ANONYMOUS_USER_ID_STORAGE_KEY,
       );
+      expect(cookieStorageMock.get).toHaveBeenCalledWith(
+        LEGACY_ANONYMOUS_USER_ID_STORAGE_KEY,
+      );
       expect(cookieStorageMock.set).toHaveBeenCalledWith(
         ANONYMOUS_USER_ID_STORAGE_KEY,
         anyString(),
@@ -41,6 +45,12 @@ describe('IdentityManager', () => {
       const identityManager = new IdentityManager(TEST_WRITE_KEY);
       const result = identityManager.getOrCreateAnonymousUserId();
 
+      expect(cookieStorageMock.get).toHaveBeenCalledWith(
+        ANONYMOUS_USER_ID_STORAGE_KEY,
+      );
+      expect(cookieStorageMock.get).not.toHaveBeenCalledWith(
+        LEGACY_ANONYMOUS_USER_ID_STORAGE_KEY,
+      );
       expect(cookieStorageMock.set).not.toHaveBeenCalled();
       expect(result).toEqual(TEST_ANONYMOUS_USER_ID);
     });

--- a/src/tests/client/managers/identity.unit.test.ts
+++ b/src/tests/client/managers/identity.unit.test.ts
@@ -1,12 +1,12 @@
 import { anyString, mock, mockReset } from 'jest-mock-extended';
 
 import {
-  LEGACY_ANONYMOUS_USER_ID_STORAGE_KEY,
+  LEGACY_VISITOR_ID_STORAGE_KEY,
   IdentityManager,
-  ANONYMOUS_USER_ID_STORAGE_KEY,
+  VISITOR_ID_STORAGE_KEY,
 } from '../../../client/managers';
 import { CookieStorageService } from '../../../client/storage';
-import { TEST_ANONYMOUS_USER_ID, TEST_WRITE_KEY } from '../../mocks/data';
+import { TEST_VISITOR_ID, TEST_WRITE_KEY } from '../../mocks/data';
 
 const cookieStorageMock = mock(CookieStorageService.prototype);
 jest.mock('../../../client/storage', () => ({
@@ -19,54 +19,54 @@ describe('IdentityManager', () => {
     mockReset(cookieStorageMock);
   });
 
-  describe('getOrCreateAnonymousUserId', () => {
-    test('creates new anonymous user ID if none exists', () => {
+  describe('getOrCreateVisitorId', () => {
+    test('creates new visitor ID if none exists', () => {
       const identityManager = new IdentityManager(TEST_WRITE_KEY);
-      const result = identityManager.getOrCreateAnonymousUserId();
+      const result = identityManager.getOrCreateVisitorId();
 
       expect(cookieStorageMock.get).toHaveBeenCalledWith(
-        ANONYMOUS_USER_ID_STORAGE_KEY,
+        VISITOR_ID_STORAGE_KEY,
       );
       expect(cookieStorageMock.get).toHaveBeenCalledWith(
-        LEGACY_ANONYMOUS_USER_ID_STORAGE_KEY,
+        LEGACY_VISITOR_ID_STORAGE_KEY,
       );
       expect(cookieStorageMock.set).toHaveBeenCalledWith(
-        ANONYMOUS_USER_ID_STORAGE_KEY,
+        VISITOR_ID_STORAGE_KEY,
         anyString(),
       );
       expect(result).toEqual(anyString());
 
-      const cachedResult = identityManager.getOrCreateAnonymousUserId();
+      const cachedResult = identityManager.getOrCreateVisitorId();
       expect(cachedResult).toEqual(result);
     });
 
-    test('gets anonymous user ID from storage if one exists', () => {
-      cookieStorageMock.get.mockReturnValueOnce(TEST_ANONYMOUS_USER_ID);
+    test('gets visitor ID from storage if one exists', () => {
+      cookieStorageMock.get.mockReturnValueOnce(TEST_VISITOR_ID);
       const identityManager = new IdentityManager(TEST_WRITE_KEY);
-      const result = identityManager.getOrCreateAnonymousUserId();
+      const result = identityManager.getOrCreateVisitorId();
 
       expect(cookieStorageMock.get).toHaveBeenCalledWith(
-        ANONYMOUS_USER_ID_STORAGE_KEY,
+        VISITOR_ID_STORAGE_KEY,
       );
       expect(cookieStorageMock.get).not.toHaveBeenCalledWith(
-        LEGACY_ANONYMOUS_USER_ID_STORAGE_KEY,
+        LEGACY_VISITOR_ID_STORAGE_KEY,
       );
       expect(cookieStorageMock.set).not.toHaveBeenCalled();
-      expect(result).toEqual(TEST_ANONYMOUS_USER_ID);
+      expect(result).toEqual(TEST_VISITOR_ID);
     });
 
-    test('gets the cached anonymous user ID if it exists', () => {
+    test('gets the cached visitor ID if it exists', () => {
       // Initialize cached value
-      cookieStorageMock.get.mockReturnValueOnce(TEST_ANONYMOUS_USER_ID);
+      cookieStorageMock.get.mockReturnValueOnce(TEST_VISITOR_ID);
       const identityManager = new IdentityManager(TEST_WRITE_KEY);
-      identityManager.getOrCreateAnonymousUserId();
+      identityManager.getOrCreateVisitorId();
 
       // Clear mock so we can test fresh state
       cookieStorageMock.get.mockClear();
 
       // Check that cached value exists
-      const result = identityManager.getOrCreateAnonymousUserId();
-      expect(result).toEqual(TEST_ANONYMOUS_USER_ID);
+      const result = identityManager.getOrCreateVisitorId();
+      expect(result).toEqual(TEST_VISITOR_ID);
       expect(cookieStorageMock.get).not.toHaveBeenCalled();
     });
   });

--- a/src/tests/client/managers/sessions.unit.test.ts
+++ b/src/tests/client/managers/sessions.unit.test.ts
@@ -2,22 +2,30 @@ import { anyNumber, mock, mockReset } from 'jest-mock-extended';
 
 import {
   LEGACY_SESSION_STORAGE_KEY,
+  SESSION_ID_STORAGE_KEY,
   SESSION_STORAGE_KEY,
   SessionManager,
 } from '../../../client/managers';
-import { LocalStorageService } from '../../../client/storage';
+import {
+  CookieStorageService,
+  LocalStorageService,
+} from '../../../client/storage';
 import { ClientSession } from '../../../types';
 import { MockClientSession, TEST_WRITE_KEY } from '../../mocks/data';
 
 const localStorageMock = mock(LocalStorageService.prototype);
+const cookieStorageMock = mock(CookieStorageService.prototype);
+
 jest.mock('../../../client/storage', () => ({
   ...jest.requireActual('../../../client/storage'),
   LocalStorageService: jest.fn().mockImplementation(() => localStorageMock),
+  CookieStorageService: jest.fn().mockImplementation(() => cookieStorageMock),
 }));
 
 describe('SessionManager', () => {
   beforeEach(() => {
     mockReset(localStorageMock);
+    mockReset(cookieStorageMock);
   });
 
   describe('getOrCreateSession', () => {
@@ -32,6 +40,10 @@ describe('SessionManager', () => {
       expect(localStorageMock.set).toHaveBeenCalledWith(
         SESSION_STORAGE_KEY,
         result,
+      );
+      expect(cookieStorageMock.set).toHaveBeenCalledWith(
+        SESSION_ID_STORAGE_KEY,
+        result.sessionId,
       );
     });
 
@@ -62,6 +74,10 @@ describe('SessionManager', () => {
             SESSION_STORAGE_KEY,
             expectedSession,
           );
+          expect(cookieStorageMock.set).toHaveBeenCalledWith(
+            SESSION_ID_STORAGE_KEY,
+            expectedSession.sessionId,
+          );
           expect(session.expiration).toBeGreaterThan(mockSession.expiration);
         });
 
@@ -87,6 +103,10 @@ describe('SessionManager', () => {
           expect(localStorageMock.set).toHaveBeenCalledWith(
             SESSION_STORAGE_KEY,
             session,
+          );
+          expect(cookieStorageMock.set).toHaveBeenCalledWith(
+            SESSION_ID_STORAGE_KEY,
+            session.sessionId,
           );
         });
       });
@@ -115,6 +135,10 @@ describe('SessionManager', () => {
           expect(localStorageMock.set).toHaveBeenCalledWith(
             SESSION_STORAGE_KEY,
             result,
+          );
+          expect(cookieStorageMock.set).toHaveBeenCalledWith(
+            SESSION_ID_STORAGE_KEY,
+            result.sessionId,
           );
         });
       });

--- a/src/tests/client/managers/sessions.unit.test.ts
+++ b/src/tests/client/managers/sessions.unit.test.ts
@@ -1,7 +1,8 @@
 import { anyNumber, mock, mockReset } from 'jest-mock-extended';
 
 import {
-  CLIENT_SESSION_STORAGE_KEY,
+  LEGACY_SESSION_ID_STORAGE_KEY,
+  SESSION_ID_STORAGE_KEY,
   SessionManager,
 } from '../../../client/managers';
 import { LocalStorageService } from '../../../client/storage';
@@ -24,11 +25,12 @@ describe('SessionManager', () => {
       const sessionManager = new SessionManager(TEST_WRITE_KEY);
       const result = sessionManager.getOrCreateSession();
 
+      expect(localStorageMock.get).toHaveBeenCalledWith(SESSION_ID_STORAGE_KEY);
       expect(localStorageMock.get).toHaveBeenCalledWith(
-        CLIENT_SESSION_STORAGE_KEY,
+        LEGACY_SESSION_ID_STORAGE_KEY,
       );
       expect(localStorageMock.set).toHaveBeenCalledWith(
-        CLIENT_SESSION_STORAGE_KEY,
+        SESSION_ID_STORAGE_KEY,
         result,
       );
     });
@@ -57,7 +59,7 @@ describe('SessionManager', () => {
 
           expect(localStorageMock.set).toHaveBeenCalledTimes(1);
           expect(localStorageMock.set).toHaveBeenCalledWith(
-            CLIENT_SESSION_STORAGE_KEY,
+            SESSION_ID_STORAGE_KEY,
             expectedSession,
           );
           expect(session.expiration).toBeGreaterThan(mockSession.expiration);
@@ -83,7 +85,7 @@ describe('SessionManager', () => {
           expect(localStorageMock.get).not.toHaveBeenCalled();
           expect(localStorageMock.set).toHaveBeenCalledTimes(1);
           expect(localStorageMock.set).toHaveBeenCalledWith(
-            CLIENT_SESSION_STORAGE_KEY,
+            SESSION_ID_STORAGE_KEY,
             session,
           );
         });
@@ -103,10 +105,15 @@ describe('SessionManager', () => {
           const sessionManager = new SessionManager(TEST_WRITE_KEY);
           const result = sessionManager.getOrCreateSession();
 
-          expect(localStorageMock.get).toHaveBeenCalledTimes(1);
+          expect(localStorageMock.get).toHaveBeenCalledWith(
+            LEGACY_SESSION_ID_STORAGE_KEY,
+          );
+          expect(localStorageMock.get).toHaveBeenCalledWith(
+            SESSION_ID_STORAGE_KEY,
+          );
           expect(localStorageMock.set).toHaveBeenCalledTimes(1);
           expect(localStorageMock.set).toHaveBeenCalledWith(
-            CLIENT_SESSION_STORAGE_KEY,
+            SESSION_ID_STORAGE_KEY,
             result,
           );
         });

--- a/src/tests/client/managers/sessions.unit.test.ts
+++ b/src/tests/client/managers/sessions.unit.test.ts
@@ -1,8 +1,8 @@
 import { anyNumber, mock, mockReset } from 'jest-mock-extended';
 
 import {
-  LEGACY_SESSION_ID_STORAGE_KEY,
-  SESSION_ID_STORAGE_KEY,
+  LEGACY_SESSION_STORAGE_KEY,
+  SESSION_STORAGE_KEY,
   SessionManager,
 } from '../../../client/managers';
 import { LocalStorageService } from '../../../client/storage';
@@ -25,12 +25,12 @@ describe('SessionManager', () => {
       const sessionManager = new SessionManager(TEST_WRITE_KEY);
       const result = sessionManager.getOrCreateSession();
 
-      expect(localStorageMock.get).toHaveBeenCalledWith(SESSION_ID_STORAGE_KEY);
+      expect(localStorageMock.get).toHaveBeenCalledWith(SESSION_STORAGE_KEY);
       expect(localStorageMock.get).toHaveBeenCalledWith(
-        LEGACY_SESSION_ID_STORAGE_KEY,
+        LEGACY_SESSION_STORAGE_KEY,
       );
       expect(localStorageMock.set).toHaveBeenCalledWith(
-        SESSION_ID_STORAGE_KEY,
+        SESSION_STORAGE_KEY,
         result,
       );
     });
@@ -59,7 +59,7 @@ describe('SessionManager', () => {
 
           expect(localStorageMock.set).toHaveBeenCalledTimes(1);
           expect(localStorageMock.set).toHaveBeenCalledWith(
-            SESSION_ID_STORAGE_KEY,
+            SESSION_STORAGE_KEY,
             expectedSession,
           );
           expect(session.expiration).toBeGreaterThan(mockSession.expiration);
@@ -85,7 +85,7 @@ describe('SessionManager', () => {
           expect(localStorageMock.get).not.toHaveBeenCalled();
           expect(localStorageMock.set).toHaveBeenCalledTimes(1);
           expect(localStorageMock.set).toHaveBeenCalledWith(
-            SESSION_ID_STORAGE_KEY,
+            SESSION_STORAGE_KEY,
             session,
           );
         });
@@ -106,14 +106,14 @@ describe('SessionManager', () => {
           const result = sessionManager.getOrCreateSession();
 
           expect(localStorageMock.get).toHaveBeenCalledWith(
-            SESSION_ID_STORAGE_KEY,
+            SESSION_STORAGE_KEY,
           );
           expect(localStorageMock.get).not.toHaveBeenCalledWith(
-            LEGACY_SESSION_ID_STORAGE_KEY,
+            LEGACY_SESSION_STORAGE_KEY,
           );
           expect(localStorageMock.set).toHaveBeenCalledTimes(1);
           expect(localStorageMock.set).toHaveBeenCalledWith(
-            SESSION_ID_STORAGE_KEY,
+            SESSION_STORAGE_KEY,
             result,
           );
         });

--- a/src/tests/client/managers/sessions.unit.test.ts
+++ b/src/tests/client/managers/sessions.unit.test.ts
@@ -106,10 +106,10 @@ describe('SessionManager', () => {
           const result = sessionManager.getOrCreateSession();
 
           expect(localStorageMock.get).toHaveBeenCalledWith(
-            LEGACY_SESSION_ID_STORAGE_KEY,
-          );
-          expect(localStorageMock.get).toHaveBeenCalledWith(
             SESSION_ID_STORAGE_KEY,
+          );
+          expect(localStorageMock.get).not.toHaveBeenCalledWith(
+            LEGACY_SESSION_ID_STORAGE_KEY,
           );
           expect(localStorageMock.set).toHaveBeenCalledTimes(1);
           expect(localStorageMock.set).toHaveBeenCalledWith(

--- a/src/tests/client/storage/cookies.unit.test.ts
+++ b/src/tests/client/storage/cookies.unit.test.ts
@@ -22,17 +22,18 @@ describe('CookieStorageService', () => {
   describe('get', () => {
     it('gets the value from underlying Cookies storage', () => {
       const storageService = new CookieStorageService(TEST_WRITE_KEY);
-      storageService.get('anonymousUserId');
+      storageService.get('unify_user_id');
+      expect(CookiesMock.get).toHaveBeenCalledWith('unify_user_id');
       expect(CookiesMock.get).toHaveBeenCalledWith(
-        encodeForStorage(`${TEST_WRITE_KEY}_anonymousUserId`),
+        encodeForStorage(`${TEST_WRITE_KEY}_unify_user_id`),
       );
     });
 
     it('works with non-latin-1 characters', () => {
       const storageService = new CookieStorageService('ő');
-      storageService.get('anonymousUserId');
+      storageService.get('unify_user_id');
       expect(CookiesMock.get).toHaveBeenCalledWith(
-        encodeForStorage(`ő_anonymousUserId`),
+        encodeForStorage(`ő_unify_user_id`),
       );
     });
   });
@@ -40,10 +41,10 @@ describe('CookieStorageService', () => {
   describe('set', () => {
     it('sets the value in the underlying Cookies storage', () => {
       const storageService = new CookieStorageService(TEST_WRITE_KEY);
-      storageService.set('anonymousUserId', TEST_ANONYMOUS_USER_ID);
+      storageService.set('unify_user_id', TEST_ANONYMOUS_USER_ID);
       expect(CookiesMock.set).toHaveBeenCalledWith(
-        encodeForStorage(`${TEST_WRITE_KEY}_anonymousUserId`),
-        encodeForStorage(TEST_ANONYMOUS_USER_ID),
+        'unify_user_id',
+        TEST_ANONYMOUS_USER_ID,
         { domain: `.${getCurrentTopLevelDomain()}`, expires: 365 },
       );
     });

--- a/src/tests/client/storage/cookies.unit.test.ts
+++ b/src/tests/client/storage/cookies.unit.test.ts
@@ -6,8 +6,8 @@ import {
   encodeForStorage,
   getCurrentTopLevelDomain,
 } from '../../../client/storage/utils';
-import { TEST_ANONYMOUS_USER_ID, TEST_WRITE_KEY } from '../../mocks/data';
-import { ANONYMOUS_USER_ID_STORAGE_KEY } from '../../../client/managers';
+import { TEST_VISITOR_ID, TEST_WRITE_KEY } from '../../mocks/data';
+import { VISITOR_ID_STORAGE_KEY } from '../../../client/managers';
 
 jest.mock('js-cookie', () => ({
   __esModule: true,
@@ -23,12 +23,10 @@ describe('CookieStorageService', () => {
   describe('get', () => {
     it('gets the value from underlying Cookies storage', () => {
       const storageService = new CookieStorageService(TEST_WRITE_KEY);
-      storageService.get(ANONYMOUS_USER_ID_STORAGE_KEY);
-      expect(CookiesMock.get).toHaveBeenCalledWith(
-        ANONYMOUS_USER_ID_STORAGE_KEY,
-      );
+      storageService.get(VISITOR_ID_STORAGE_KEY);
+      expect(CookiesMock.get).toHaveBeenCalledWith(VISITOR_ID_STORAGE_KEY);
       expect(CookiesMock.get).toHaveBeenLastCalledWith(
-        encodeForStorage(`${TEST_WRITE_KEY}_unify_user_id`),
+        encodeForStorage(`${TEST_WRITE_KEY}_${VISITOR_ID_STORAGE_KEY}`),
       );
     });
   });
@@ -36,11 +34,11 @@ describe('CookieStorageService', () => {
   describe('set', () => {
     it('sets the value in the underlying Cookies storage', () => {
       const storageService = new CookieStorageService(TEST_WRITE_KEY);
-      storageService.set(ANONYMOUS_USER_ID_STORAGE_KEY, TEST_ANONYMOUS_USER_ID);
+      storageService.set(VISITOR_ID_STORAGE_KEY, TEST_VISITOR_ID);
       expect(CookiesMock.set).toHaveBeenCalledWith(
-        ANONYMOUS_USER_ID_STORAGE_KEY,
-        TEST_ANONYMOUS_USER_ID,
-        { domain: `.${getCurrentTopLevelDomain()}`, expires: 365 },
+        VISITOR_ID_STORAGE_KEY,
+        TEST_VISITOR_ID,
+        { domain: `.${getCurrentTopLevelDomain()}`, expires: 400 },
       );
     });
   });

--- a/src/tests/client/storage/cookies.unit.test.ts
+++ b/src/tests/client/storage/cookies.unit.test.ts
@@ -7,6 +7,7 @@ import {
   getCurrentTopLevelDomain,
 } from '../../../client/storage/utils';
 import { TEST_ANONYMOUS_USER_ID, TEST_WRITE_KEY } from '../../mocks/data';
+import { ANONYMOUS_USER_ID_STORAGE_KEY } from '../../../client/managers';
 
 jest.mock('js-cookie', () => ({
   __esModule: true,
@@ -22,18 +23,12 @@ describe('CookieStorageService', () => {
   describe('get', () => {
     it('gets the value from underlying Cookies storage', () => {
       const storageService = new CookieStorageService(TEST_WRITE_KEY);
-      storageService.get('unify_user_id');
-      expect(CookiesMock.get).toHaveBeenCalledWith('unify_user_id');
+      storageService.get(ANONYMOUS_USER_ID_STORAGE_KEY);
       expect(CookiesMock.get).toHaveBeenCalledWith(
-        encodeForStorage(`${TEST_WRITE_KEY}_unify_user_id`),
+        ANONYMOUS_USER_ID_STORAGE_KEY,
       );
-    });
-
-    it('works with non-latin-1 characters', () => {
-      const storageService = new CookieStorageService('ő');
-      storageService.get('unify_user_id');
-      expect(CookiesMock.get).toHaveBeenCalledWith(
-        encodeForStorage(`ő_unify_user_id`),
+      expect(CookiesMock.get).toHaveBeenLastCalledWith(
+        encodeForStorage(`${TEST_WRITE_KEY}_unify_user_id`),
       );
     });
   });
@@ -41,20 +36,10 @@ describe('CookieStorageService', () => {
   describe('set', () => {
     it('sets the value in the underlying Cookies storage', () => {
       const storageService = new CookieStorageService(TEST_WRITE_KEY);
-      storageService.set('unify_user_id', TEST_ANONYMOUS_USER_ID);
+      storageService.set(ANONYMOUS_USER_ID_STORAGE_KEY, TEST_ANONYMOUS_USER_ID);
       expect(CookiesMock.set).toHaveBeenCalledWith(
-        'unify_user_id',
+        ANONYMOUS_USER_ID_STORAGE_KEY,
         TEST_ANONYMOUS_USER_ID,
-        { domain: `.${getCurrentTopLevelDomain()}`, expires: 365 },
-      );
-    });
-
-    it('works with non-latin-1 characters', () => {
-      const storageService = new CookieStorageService('ő');
-      storageService.set('anonymousUserId', TEST_ANONYMOUS_USER_ID);
-      expect(CookiesMock.set).toHaveBeenCalledWith(
-        encodeForStorage(`ő_anonymousUserId`),
-        encodeForStorage(TEST_ANONYMOUS_USER_ID),
         { domain: `.${getCurrentTopLevelDomain()}`, expires: 365 },
       );
     });

--- a/src/tests/client/storage/local-storage.unit.test.ts
+++ b/src/tests/client/storage/local-storage.unit.test.ts
@@ -10,21 +10,25 @@ jest.mock('../../../client/storage/utils', () => ({
   isLocalStorageAvailable: jest.fn(),
 }));
 
-const mockedIsLocalStorageAvailable = jest.mocked<
-  typeof isLocalStorageAvailable
->(isLocalStorageAvailable);
-const mockedGetItem = jest.mocked<typeof localStorage.getItem>(
-  localStorage.getItem,
-);
-const mockedSetItem = jest.mocked<typeof localStorage.setItem>(
-  localStorage.setItem,
-);
+const mockedIsLocalStorageAvailable = jest.mocked(isLocalStorageAvailable);
 
 describe('LocalStorageService', () => {
+  const mockGetItem = jest.fn();
+  const mockSetItem = jest.fn();
+  const mockRemoveItem = jest.fn();
+
+  Object.defineProperty(window, 'localStorage', {
+    value: {
+      getItem: (...args: string[]) => mockGetItem(...args),
+      setItem: (...args: string[]) => mockSetItem(...args),
+      removeItem: (...args: string[]) => mockRemoveItem(...args),
+    },
+  });
+
   beforeEach(() => {
-    localStorage.clear();
-    mockedGetItem.mockClear();
-    mockedSetItem.mockClear();
+    mockGetItem.mockClear();
+    mockSetItem.mockClear();
+    mockRemoveItem.mockClear();
   });
 
   describe('get', () => {
@@ -36,16 +40,9 @@ describe('LocalStorageService', () => {
       it('gets the value from underlying local storage', () => {
         const storageService = new LocalStorageService(TEST_WRITE_KEY);
         storageService.get('clientSession');
-        expect(localStorage.getItem).toHaveBeenLastCalledWith(
+        expect(mockGetItem).toHaveBeenCalledWith('clientSession');
+        expect(mockGetItem).toHaveBeenLastCalledWith(
           encodeForStorage(`${TEST_WRITE_KEY}_clientSession`),
-        );
-      });
-
-      it('works with non-latin-1 characters', () => {
-        const storageService = new LocalStorageService('ő');
-        storageService.get('clientSession');
-        expect(localStorage.getItem).toHaveBeenLastCalledWith(
-          encodeForStorage(`ő_clientSession`),
         );
       });
     });
@@ -56,10 +53,9 @@ describe('LocalStorageService', () => {
       });
 
       it('does nothing', () => {
-        mockedIsLocalStorageAvailable.mockReturnValue(false);
         const storageService = new LocalStorageService(TEST_WRITE_KEY);
         storageService.get('clientSession');
-        expect(localStorage.getItem).not.toHaveBeenCalled();
+        expect(mockGetItem).not.toHaveBeenCalled();
       });
     });
   });
@@ -73,28 +69,16 @@ describe('LocalStorageService', () => {
       it('sets the value in the underlying local storage', () => {
         const storageService = new LocalStorageService(TEST_WRITE_KEY);
         storageService.set('key', '1234');
-        expect(localStorage.setItem).toHaveBeenLastCalledWith(
-          encodeForStorage(`${TEST_WRITE_KEY}_key`),
-          encodeForStorage('1234'),
-        );
-      });
-
-      it('works with non-latin-1 characters', () => {
-        const storageService = new LocalStorageService('ő');
-        storageService.set('key', '1234');
-        expect(localStorage.setItem).toHaveBeenLastCalledWith(
-          encodeForStorage(`ő_key`),
-          encodeForStorage('1234'),
-        );
+        expect(mockSetItem).toHaveBeenLastCalledWith('key', '1234');
       });
 
       it('works for complex object storage', () => {
         const mockClientSession = MockClientSession();
         const storageService = new LocalStorageService(TEST_WRITE_KEY);
         storageService.set('key', mockClientSession);
-        expect(localStorage.setItem).toHaveBeenLastCalledWith(
-          encodeForStorage(`${TEST_WRITE_KEY}_key`),
-          encodeForStorage(mockClientSession),
+        expect(mockSetItem).toHaveBeenLastCalledWith(
+          'key',
+          JSON.stringify(mockClientSession),
         );
       });
     });
@@ -107,7 +91,7 @@ describe('LocalStorageService', () => {
       it('does nothing', () => {
         const storageService = new LocalStorageService(TEST_WRITE_KEY);
         storageService.set('key', '1234');
-        expect(localStorage.setItem).not.toHaveBeenCalled();
+        expect(mockSetItem).not.toHaveBeenCalled();
       });
     });
   });

--- a/src/tests/client/storage/local-storage.unit.test.ts
+++ b/src/tests/client/storage/local-storage.unit.test.ts
@@ -69,16 +69,24 @@ describe('LocalStorageService', () => {
       it('sets the value in the underlying local storage', () => {
         const storageService = new LocalStorageService(TEST_WRITE_KEY);
         storageService.set('key', '1234');
-        expect(mockSetItem).toHaveBeenLastCalledWith('key', '1234');
+        expect(mockSetItem).toHaveBeenCalledWith('key', '1234');
+        expect(mockSetItem).toHaveBeenLastCalledWith(
+          encodeForStorage(`${TEST_WRITE_KEY}_key`),
+          encodeForStorage('1234'),
+        );
       });
 
       it('works for complex object storage', () => {
         const mockClientSession = MockClientSession();
         const storageService = new LocalStorageService(TEST_WRITE_KEY);
         storageService.set('key', mockClientSession);
-        expect(mockSetItem).toHaveBeenLastCalledWith(
+        expect(mockSetItem).toHaveBeenCalledWith(
           'key',
           JSON.stringify(mockClientSession),
+        );
+        expect(mockSetItem).toHaveBeenLastCalledWith(
+          encodeForStorage(`${TEST_WRITE_KEY}_key`),
+          encodeForStorage(mockClientSession),
         );
       });
     });

--- a/src/tests/client/unify-intent-client.unit.test.ts
+++ b/src/tests/client/unify-intent-client.unit.test.ts
@@ -80,9 +80,7 @@ describe('UnifyIntentClient', () => {
     const unify = new UnifyIntentClient(TEST_WRITE_KEY);
     unify.mount();
 
-    expect(
-      mockedIdentityManager.getOrCreateAnonymousUserId,
-    ).toHaveBeenCalledTimes(1);
+    expect(mockedIdentityManager.getOrCreateVisitorId).toHaveBeenCalledTimes(1);
     expect(mockedSessionManager.getOrCreateSession).toHaveBeenCalledTimes(1);
 
     unify.unmount();

--- a/src/tests/mocks/data.ts
+++ b/src/tests/mocks/data.ts
@@ -8,7 +8,7 @@ import {
 } from '../../types';
 
 export const TEST_WRITE_KEY = '1234';
-export const TEST_ANONYMOUS_USER_ID = '5678';
+export const TEST_VISITOR_ID = '5678';
 
 export const MockUTM = {
   source: 'google',

--- a/src/types.ts
+++ b/src/types.ts
@@ -19,6 +19,14 @@ export interface UnifyIntentClientConfig {
    * @default false
    */
   autoIdentify?: boolean;
+
+  /**
+   * The amount of time in minutes that user sessions will persist even when
+   * no activities are tracked for the user. Activities which update the
+   * expiration time of sessions are `page`, `identify`, and `track` activities.
+   * @default 30
+   */
+  sessionDurationMinutes?: number;
 }
 
 export interface UnifyIntentContext {


### PR DESCRIPTION
Today, the intent client stores the anonymous user ID and client session in a pretty funky way. Basically, instead of storing a simple key by name and a raw value, it does the following with both the key and value before storing them:

1. Convert to JSON with `JSON.stringify`
2. Encode result to a base 64 string

The exact reason for why we do this isn't known, and the engineer who implemented it this way is no longer around. Our best guess is that it was done in an attempt to obfuscate the fact that we were storing things, but this is not only totally unnecessary, but also makes it difficult for developers who use the client to test that it is working. Perhaps most importantly, it makes it very difficult to reliably extract the anonymous user ID from cookies when they are forwarded to an HTTP server.

This PR updates the intent client to use a much more straightforward strategy for storage in both cookies (anonymous user ID) and client session (local storage):

1. Store a simple key name (`unify_user_id` for anonymous user ID and `unify_session` for client session object)
2. If the value to store is a string (e.g. the anonymous user ID) then store it directly. If the value to store is an object (e.g. client session data) then first convert to JSON with `JSON.stringify` and then store the result directly.

## Backwards compatibility

This PR is sensitive because it is very important that these changes are 100% backwards compatible with old client versions and the keys/values stored by old client versions. If we simply removed the old code entirely, then millions of users with anonymous user IDs already tracked would suddenly disappear.

To prevent this, for the time being we will continue to set the old encoded keys and values and fall back to trying to retrieve them whenever the new keys are not present in storage.