### PR TITLE
Add `track` and click auto-tracking to intent client

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ When you include this tag in your HTML, you will immediately be able to access t
 
 This method is typically used to install the client in e.g. frontend application code such as a Single Page App (SPA) (as opposed to on a static marketing website).
 
-> [!NOTE]
-> See [@unifygtm/intent-react](https://www.npmjs.com/package/@unifygtm/intent-react) if you are using React.
+**NOTE:**: See [@unifygtm/intent-react](https://www.npmjs.com/package/@unifygtm/intent-react) if you are using React.
 
 You can install the client package directly using your preferred package manager:
 
@@ -54,8 +53,7 @@ const unify = new UnifyIntentClient(writeKey, config);
 unify.mount();
 ```
 
-> [!NOTE]
-> The `mount` method on the client is used to initialize it once it is in a browser context. If your application uses server side rendering, you should be sure not to call `mount()` until the code is running in a browser context.
+**NOTE:** The `mount` method on the client is used to initialize it once it is in a browser context. If your application uses server side rendering, you should be sure not to call `mount()` until the code is running in a browser context.
 
 Once the client is initialized and mounted it will be immediately ready for use. See [Usage](#usage) below for how to use the client after installing. If you wish to cleanup the side effects created by initializing the client (e.g. event listeners), you can do so with the `unmount` method. Here is an example of mounting and unmounting the client in React code:
 
@@ -83,8 +81,7 @@ const TestComponent = () => {
 
 ## Cookies
 
-> [!NOTE]
-> This section only applies to intent client versions `1.4.0` and up. If you install the intent client with the website tag, you automatically get access to the latest client version. Versions older than this use obfuscated cookie names. If for some reason you need access to these then you can reach out to the Unify team for support.
+**NOTE:** This section only applies to intent client versions `1.4.0` and up. If you install the intent client with the website tag, you automatically get access to the latest client version. Versions older than this use obfuscated cookie names. If for some reason you need access to these then you can reach out to the Unify team for support.
 
 When the intent client mounts, it places two values in the user's cookies:
 
@@ -193,6 +190,75 @@ const currentUser = getCurrentUser();
 unify.identify(currentUser.emailAddress);
 ```
 
+### Track Events
+
+Certain user actions are valuable indicators of buying intent. You can use `track` events to log these events along with custom properties for each event that you can then use within Unify to filter your visitors and take action accordingly.
+
+There are three ways to fire track events with the Unify intent client:
+
+1. Custom HTML data attributes
+2. Manually via the client `track` method
+3. Automatically with CSS selectors
+
+#### HTML data attributes
+
+You can leverage various data attributes in the HTML of your site or application to automatically track click events for elements you care about:
+
+`data-unify-track-clicks`
+This attribute indicates that the intent client should automatically fire a track event when the element is clicked. The client will make a best effort at determining a label to use for the element, but if it cannot determine one then an event will _not_ be fired. If an element you would like to track does not contain any text to be used as a name, you can leverage the `data-unify-label` attribute (see below).
+
+`data-unify-label`
+This attribute can be used to override the default name (or provide a name which is otherwise missing) for an element that is tracked by the client.
+
+`data-unify-attr-`
+By default, only the name of the element is included in the `properties` of auto-tracked events. You can specify additional properties to include using this prefix. For example, setting `data-unify-attr-custom-property="100"` will result in the `properties` of the track event including `customProperty: "100"`.
+
+#### Manual tracking
+
+You can also manually trigger a track event with the `track` method on the client:
+
+```TypeScript
+const unify = new UnifyIntentClient('YOUR_PUBLIC_API_KEY');
+unify.mount();
+
+// Only the event name is required - we recommend spaces between capitalized words
+unify.track('See More Button Clicked');
+
+// You can also specify custom properties to include
+unify.track('Modal Opened', { modalName: 'Contact Sales Modal' });
+```
+
+The `track` method accepts two arguments:
+
+1. A string `name` (required) - this is used to identify the event downstream within Unify.
+2. An object of keys and string values `properties` (optional) - this is used to specify custom properties associated with the event which can be used for filtering and identification downstream within Unify.
+
+#### Automatic tracking
+
+The Unify intent client is capable of automatically monitoring elements that match a list of CSS selectors specified by you in the `UnifyIntentClientConfig`'s `autoTrackOptions.clickTrackingSelectors`. When an element matching one of these selectors is clicked by the user, the client will automatically fire a `track` event for it with the event name `Element Clicked`. You can use the `data-unify-label` to customize the name of the element in the event `properties` and the `data-unify-attr-` prefix to add custom `properties`. See [HTML data attributes](#html-data-attributes) for more info.
+
+If you would like to exclude a specific element from tracking which matches your specified CSS selectors list, you can do so with the `data-unify-exclude` attribute.
+
+This behavior can be enabled or disabled programmatically via the `startAutoTrack` and `stopAutoTrack` methods on the client:
+
+```TypeScript
+// Initialize the client and tell it to automatically track clicks for all elements with class="button"
+const unify = new UnifyIntentClient(
+  'YOUR_PUBLIC_API_KEY',
+  { autoTrackOptions: { clickTrackingSelectors: ['.button'] } },
+);
+unify.mount();
+
+// Tell the client to stop monitoring buttons for now
+unify.stopAutoTrack();
+
+// Tell the client to start monitoring buttons again
+unify.startAutoTrack();
+
+// OR tell the client to start monitoring something else
+unify.startAutoTrack({ clickTrackingSelectors: ['.custom-button'] });
+```
+
 ## Configuration
 
 The following configuration options can be passed when initializing the client:
@@ -201,5 +267,7 @@ The following configuration options can be passed when initializing the client:
   - **Default**: `true` if the client is installed via the Unify JavaScript tag, `false` if installed via a package manager
 - `autoIdentify` - Tells the client to automatically monitor text and email input elements on the page for changes. When the current user enters a valid email address into an input, the client will log an `identify` event for that email address.
   - **Default**: `true` if the client is installed via the Unify JavaScript tag, `false` if installed via a package manager
+- `autoTrackOptions` - Options to customize the auto-tracking of user actions such as click events:
+  - `clickTrackingSelectors` - Optional list of CSS selectors to customize which elements the client will automatically fire a `track` event for when clicked.
 - `sessionDurationMinutes` - Length in minutes that user sessions will persist when no activities are tracked. Activities include `page`, `identify,` and `track` activities.
   - **Default**: `30`

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ Website page views are an indicator of buyer intent. You can log this informatio
 
 There are two ways to collect page data with the Unify intent client:
 
-1. Automatic monitoring of the current page
-2. Manually via the client `page` method
+1. Automatic monitoring of the current page (see [here](#automatic-page-monitoring))
+2. Manually via the client `page` method (see [here](#manual-page-logging))
 
 Utilizing both of these methods when appropriate is recommended to take full advantage of intent data within Unify.
 
@@ -159,8 +159,8 @@ All intent data collected for users by Unify is anonymous by default. When inten
 
 There are two ways to collect identity data with the Unify intent client:
 
-1. Automatic monitoring of email input elements
-2. Manually via the client `identify` method
+1. Automatic monitoring of email input elements (see [here](#automatic-input-monitoring))
+2. Manually via the client `identify` method (see [here](#manual-identification))
 
 Utilizing both of these methods when appropriate is recommended to take full advantage of intent data within Unify.
 
@@ -206,9 +206,9 @@ Certain user actions are valuable indicators of buying intent. You can use `trac
 
 There are three ways to fire track events with the Unify intent client:
 
-1. Custom HTML data attributes
-2. Manually via the client `track` method
-3. Automatically with CSS selectors
+1. Custom HTML data attributes (see [here](#html-data-attributes))
+2. Manually via the client `track` method (see [here](#manual-tracking))
+3. Automatically with CSS selectors (see [here](#automatic-tracking))
 
 #### HTML data attributes
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,16 @@
 
 JavaScript client for interacting with the Unify Intent API in the browser.
 
+## Table of Contents
+
+- [Installation](#installation)
+- [Cookies](#cookies)
+- [Usage](#usage)
+  - [Page Events](#page-view-events)
+  - [Identify Events](#identify-events)
+  - [Track Events](#track-events)
+- [Configuration](#configuration)
+
 ## Installation
 
 There are two ways to install the Unify Intent JS Client for two different use cases. **You should only use one of these**.

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "build:browser:s3:prod": "pnpm build:browser && aws s3 cp ./dist/js/browser/index.min.js s3://unifygtm-public/tag/v1/script.js",
     "build:browser:s3:staging": "pnpm build:browser && aws s3 cp ./dist/js/browser/index.min.js s3://unifygtm-public/tag/v1/script-staging.js",
     "build:browser:s3:testing": "pnpm build:browser && aws s3 cp ./dist/js/browser/index.min.js s3://unifygtm-public/tag/v1/script-testing.js",
-    "generate": "pnpm openapi-typescript '../unify/api/tsp-output/@typespec/openapi3/openapi.UnifyAnalyticsApi.yaml' -o './src/spec.ts'",
+    "generate": "pnpm openapi-typescript '../unify/api/spec/tsp-output/@typespec/openapi3/openapi.UnifyAnalyticsApi.json' -o './src/spec.ts'",
     "test": "pnpm jest unit.test",
     "serve": "http-server . -a localhost -p 3001 -o /test.html"
   },

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -32,7 +32,7 @@ export const initBrowser = function () {
     autoPage: true,
     autoIdentify: true,
     autoTrackOptions: {
-      trackButtonClicks: true,
+      clickTrackingSelectors: [],
     },
   }).mount();
 };

--- a/src/browser/index.ts
+++ b/src/browser/index.ts
@@ -31,6 +31,9 @@ export const initBrowser = function () {
   new UnifyIntentClient(writeKey, {
     autoPage: true,
     autoIdentify: true,
+    autoTrackOptions: {
+      trackButtonClicks: true,
+    },
   }).mount();
 };
 

--- a/src/client/activities/activity.ts
+++ b/src/client/activities/activity.ts
@@ -62,7 +62,7 @@ abstract class Activity<TActivityData extends object> {
    */
   private getBaseActivityPayload = (): AnalyticsEventBase => ({
     type: this.getActivityType(),
-    anonymousUserId: this._intentContext.identityManager.getOrCreateVisitorId(),
+    visitorId: this._intentContext.identityManager.getOrCreateVisitorId(),
     sessionId:
       this._intentContext.sessionManager.getOrCreateSession().sessionId,
     context: getActivityContext(),

--- a/src/client/activities/index.ts
+++ b/src/client/activities/index.ts
@@ -1,2 +1,3 @@
 export * from './page';
 export * from './identify';
+export * from './track';

--- a/src/client/activities/track.ts
+++ b/src/client/activities/track.ts
@@ -1,0 +1,40 @@
+import {
+  AnalyticsEventType,
+  TrackEventData,
+  UnifyIntentContext,
+} from '../../types';
+import { UNIFY_INTENT_V1_URL } from '../constants';
+import Activity from './activity';
+
+export const UNIFY_INTENT_TRACK_URL = `${UNIFY_INTENT_V1_URL}/track`;
+
+/**
+ * Activity for logging a `track` event via the Unify Intent Client.
+ */
+export class TrackActivity extends Activity<TrackEventData> {
+  private readonly _name: string;
+  private readonly _properties: TrackEventData['properties'];
+
+  constructor(
+    intentContext: UnifyIntentContext,
+    { name, properties }: Pick<TrackEventData, 'name' | 'properties'>,
+  ) {
+    super(intentContext);
+    this._name = name;
+    this._properties = properties;
+  }
+
+  protected getActivityType(): AnalyticsEventType {
+    return 'track' as TrackEventData['type'];
+  }
+
+  protected getActivityURL(): string {
+    return UNIFY_INTENT_TRACK_URL;
+  }
+
+  protected getActivityData = (): TrackEventData => ({
+    type: 'track' as TrackEventData['type'],
+    name: this._name,
+    properties: this._properties,
+  });
+}

--- a/src/client/agent/constants.ts
+++ b/src/client/agent/constants.ts
@@ -1,8 +1,14 @@
 import { DefaultEventType } from './types/default';
 
+/**
+ * This is the name of the data attribute which can be
+ * specified on an element on the page to designate that clicking the
+ * element should automatically fire a track event. By default, the content
+ * of the element will be used for the name in the event properties, but
+ * `data-unify-label` can be used to override that name.
+ */
 export const UNIFY_TRACK_CLICK_DATA_ATTR_SELECTOR_NAME =
   'data-unify-track-clicks';
-export const UNIFY_TRACK_CLICK_DATA_ATTR = 'unifyTrackClick';
 
 /**
  * This is the camel case name of the data attribute which can be
@@ -21,13 +27,13 @@ export const UNIFY_ELEMENT_LABEL_DATA_ATTR = 'unifyLabel';
  * custom properties in the track event properties.
  *
  * For example, when a `<button>` has the attributes:
- * - `data-unify-capture-attr-custom-property="1"`
- * - `data-unify-capture-attr-another-property="100"`
+ * - `data-unify-attr-custom-property="1"`
+ * - `data-unify-attr-another-property="100"`
  *
  * The auto-track event will contain `properties`:
- * `{ "CustomProperty": "1", "AnotherProperty": "100" }`
+ * `{ "customProperty": "1", "anotherProperty": "100" }`
  */
-export const UNIFY_CAPTURE_ATTRIBUTES_DATA_ATTR_PREFIX = 'unifyCaptureAttr';
+export const UNIFY_ATTRIBUTES_DATA_ATTR_PREFIX = 'unifyAttr';
 
 /**
  * This is the camel case name of the data attribute which can be

--- a/src/client/agent/constants.ts
+++ b/src/client/agent/constants.ts
@@ -1,5 +1,41 @@
 import { DefaultEventType } from './types/default';
 
+/**
+ * This is the camel case name of the data attribute which can be
+ * specified on an auto-tracked element (e.g. a `<button>` element) in
+ * order to override the name of the element in the auto-tracked properties.
+ *
+ * For example, when a `<button>` with `data-unify-label="Custom"` is clicked
+ * and auto-tracking is enabled, the `buttonName` in the track event properties
+ * will be set to "Custom" even if the element contains different text.
+ */
+export const UNIFY_ELEMENT_LABEL_DATA_ATTR = 'unifyLabel';
+
+/**
+ * This is the prefix for data attributes which can be specified on
+ * auto-tracked elements (e.g. `<button>` elements) in order to include
+ * custom properties in the track event properties.
+ *
+ * For example, when a `<button>` has the attributes:
+ * - `data-unify-capture-attr-custom-property="1"`
+ * - `data-unify-capture-attr-another-property="100"`
+ *
+ * The auto-track event will contain `properties`:
+ * `{ "CustomProperty": "1", "AnotherProperty": "100" }`
+ */
+export const UNIFY_CAPTURE_ATTRIBUTES_DATA_ATTR_PREFIX = 'unifyCaptureAttr';
+
+/**
+ * This is the camel case name of the data attribute which can be
+ * specified on an auto-tracked element (e.g. a `<button>` element) in
+ * order to exclude it from auto-tracking.
+ *
+ * For example, when a `<button>` with `data-unify-exclude` is clicked
+ * and auto-tracking is enabled, the click will _not_ be auto-tracked
+ * even though it would under normal circumstances.
+ */
+export const UNIFY_ELEMENT_EXCLUSION_DATA_ATTR = 'unifyExclude';
+
 export const DEFAULT_FORMS_IFRAME_ORIGIN = 'https://forms.default.com';
 export const NAVATTIC_IFRAME_ORIGIN = 'https://capture.navattic.com';
 

--- a/src/client/agent/constants.ts
+++ b/src/client/agent/constants.ts
@@ -1,5 +1,9 @@
 import { DefaultEventType } from './types/default';
 
+export const UNIFY_TRACK_CLICK_DATA_ATTR_SELECTOR_NAME =
+  'data-unify-track-clicks';
+export const UNIFY_TRACK_CLICK_DATA_ATTR = 'unifyTrackClick';
+
 /**
  * This is the camel case name of the data attribute which can be
  * specified on an auto-tracked element (e.g. a `<button>` element) in
@@ -35,6 +39,15 @@ export const UNIFY_CAPTURE_ATTRIBUTES_DATA_ATTR_PREFIX = 'unifyCaptureAttr';
  * even though it would under normal circumstances.
  */
 export const UNIFY_ELEMENT_EXCLUSION_DATA_ATTR = 'unifyExclude';
+
+export const BUTTON_SELECTORS = [
+  'button',
+  "[role='button']",
+  "input[type='button']",
+  "input[type='submit']",
+  "input[type='reset']",
+  "input[type='image']",
+];
 
 export const DEFAULT_FORMS_IFRAME_ORIGIN = 'https://forms.default.com';
 export const NAVATTIC_IFRAME_ORIGIN = 'https://capture.navattic.com';

--- a/src/client/agent/utils.ts
+++ b/src/client/agent/utils.ts
@@ -1,4 +1,9 @@
-import { DEFAULT_FORM_EVENT_TYPES } from './constants';
+import {
+  DEFAULT_FORM_EVENT_TYPES,
+  UNIFY_CAPTURE_ATTRIBUTES_DATA_ATTR_PREFIX,
+  UNIFY_ELEMENT_EXCLUSION_DATA_ATTR,
+  UNIFY_ELEMENT_LABEL_DATA_ATTR,
+} from './constants';
 import {
   DefaultEventData,
   DefaultFormCompletedEventData,
@@ -13,4 +18,135 @@ export function isDefaultFormEventData(
   | DefaultFormPageSubmittedEventData
   | DefaultFormPageSubmittedV2EventData {
   return DEFAULT_FORM_EVENT_TYPES.includes(data.event);
+}
+
+export function isActionableButton(element: Element): boolean {
+  if (isElementHidden(element)) return false;
+
+  const isDisabled =
+    (element as HTMLButtonElement | HTMLInputElement).disabled === true ||
+    element.getAttribute('aria-disabled') === 'true';
+  if (isDisabled) return false;
+
+  if (elementHasDataAttr(element, UNIFY_ELEMENT_EXCLUSION_DATA_ATTR))
+    return false;
+
+  return true;
+}
+
+export function getElementName(element: Element): string | null {
+  const unifyDataLabel = getElementDataAttr(
+    element,
+    UNIFY_ELEMENT_LABEL_DATA_ATTR,
+  );
+  if (unifyDataLabel) return unifyDataLabel;
+
+  const textName = getElementTextContent(element);
+  if (textName) return normalizeName(textName);
+
+  const ariaLabel = element.getAttribute('aria-label');
+  if (ariaLabel) return normalizeName(ariaLabel);
+
+  const labelledBy = getElementLabelledBy(element);
+  if (labelledBy) return normalizeName(labelledBy);
+
+  const imageAlt = getElementImageAlt(element);
+  if (imageAlt) return normalizeName(imageAlt);
+
+  return null;
+}
+
+export function extractUnifyCapturePropertiesFromElement(
+  element: Element,
+): Record<string, string> {
+  if (!(element instanceof HTMLElement)) return {};
+
+  const result: Record<string, string> = {};
+  Object.entries(element.dataset).forEach(([key, value]) => {
+    if (key.startsWith(UNIFY_CAPTURE_ATTRIBUTES_DATA_ATTR_PREFIX) && value) {
+      const effectiveKey = key.slice(
+        UNIFY_CAPTURE_ATTRIBUTES_DATA_ATTR_PREFIX.length,
+      );
+      if (effectiveKey) {
+        result[
+          `${effectiveKey.charAt(0).toLowerCase()}${effectiveKey.slice(1)}`
+        ] = value;
+      }
+    }
+  });
+
+  return result;
+}
+
+/**
+ * Helper function to check if an element is hidden.
+ *
+ * @param element - the element to check visibility for
+ * @returns `true` if the element is hidden to the user, otherwise `false`
+ */
+function isElementHidden(element: Element): boolean {
+  if (!(element instanceof HTMLElement)) return false;
+
+  if (element.hidden || element.getAttribute('aria-hidden') === 'true') {
+    return true;
+  }
+
+  const style = getComputedStyle(element);
+  return style.display === 'none' || style.visibility === 'hidden';
+}
+
+function normalizeName(
+  name: string | null | undefined,
+  max = 80,
+): string | null {
+  if (!name) return null;
+
+  const trimmed = name.replace(/\s+/g, ' ').trim();
+  if (!trimmed) return null;
+
+  return trimmed.length > max ? trimmed.slice(0, max - 1) + '...' : trimmed;
+}
+
+function getElementTextContent(element: Element): string | null {
+  return (element as HTMLElement).innerText || element.textContent || '';
+}
+
+function getElementLabelledBy(element: Element): string | null {
+  const labelledByIds = element.getAttribute('aria-labelledby');
+  if (!labelledByIds) return null;
+
+  return labelledByIds
+    .split(/\s+/)
+    .map((id) => {
+      const labelElement = document.getElementById(id);
+      if (!labelElement) return null;
+
+      return getElementTextContent(labelElement);
+    })
+    .filter((label) => !!label)
+    .join(' ');
+}
+
+function getElementImageAlt(element: Element): string | null {
+  const img = element.querySelector('img[alt]') as HTMLImageElement | null;
+
+  return img?.alt || null;
+}
+
+function elementHasDataAttr(element: Element, attr: string): boolean {
+  if (!(element instanceof HTMLElement)) return false;
+
+  const { dataset } = element;
+  return !!dataset[attr];
+}
+
+function getElementDataAttr(element: Element, attr: string): string | null {
+  if (!(element instanceof HTMLElement)) return null;
+
+  const { dataset } = element;
+  if (dataset[attr]) {
+    return String(dataset[attr]);
+  }
+
+  return null;
 }

--- a/src/client/agent/utils.ts
+++ b/src/client/agent/utils.ts
@@ -20,7 +20,7 @@ export function isDefaultFormEventData(
   return DEFAULT_FORM_EVENT_TYPES.includes(data.event);
 }
 
-export function isActionableButton(element: Element): boolean {
+export function isActionableElement(element: Element): boolean {
   if (isElementHidden(element)) return false;
 
   const isDisabled =

--- a/src/client/agent/utils.ts
+++ b/src/client/agent/utils.ts
@@ -1,6 +1,6 @@
 import {
   DEFAULT_FORM_EVENT_TYPES,
-  UNIFY_CAPTURE_ATTRIBUTES_DATA_ATTR_PREFIX,
+  UNIFY_ATTRIBUTES_DATA_ATTR_PREFIX,
   UNIFY_ELEMENT_EXCLUSION_DATA_ATTR,
   UNIFY_ELEMENT_LABEL_DATA_ATTR,
 } from './constants';
@@ -63,10 +63,8 @@ export function extractUnifyCapturePropertiesFromElement(
 
   const result: Record<string, string> = {};
   Object.entries(element.dataset).forEach(([key, value]) => {
-    if (key.startsWith(UNIFY_CAPTURE_ATTRIBUTES_DATA_ATTR_PREFIX) && value) {
-      const effectiveKey = key.slice(
-        UNIFY_CAPTURE_ATTRIBUTES_DATA_ATTR_PREFIX.length,
-      );
+    if (key.startsWith(UNIFY_ATTRIBUTES_DATA_ATTR_PREFIX) && value) {
+      const effectiveKey = key.slice(UNIFY_ATTRIBUTES_DATA_ATTR_PREFIX.length);
       if (effectiveKey) {
         result[
           `${effectiveKey.charAt(0).toLowerCase()}${effectiveKey.slice(1)}`

--- a/src/client/unify-intent-client.ts
+++ b/src/client/unify-intent-client.ts
@@ -88,13 +88,7 @@ export default class UnifyIntentClient {
     };
 
     // Initialize intent agent if specifed by config
-    if (
-      this._config.autoPage ||
-      this._config.autoIdentify ||
-      this._config.autoTrackOptions
-    ) {
-      this._intentAgent = new UnifyIntentAgent(this._context);
-    }
+    this._intentAgent = new UnifyIntentAgent(this._context);
 
     // We set `mounted` to `true` before flushing the queue since the
     // methdods which can be called require that.
@@ -127,9 +121,7 @@ export default class UnifyIntentClient {
       this.stopAutoIdentify();
     }
 
-    if (this._config.autoTrackOptions) {
-      this.stopAutoTrack();
-    }
+    this.stopAutoTrack();
 
     this._mounted = false;
     window.unify = undefined;

--- a/src/client/unify-intent-client.ts
+++ b/src/client/unify-intent-client.ts
@@ -1,5 +1,7 @@
 import {
+  AnalyticsEventBase,
   PageEventOptions,
+  TrackEventData,
   UnifyIntentClientConfig,
   UnifyIntentContext,
 } from '../types';
@@ -10,6 +12,7 @@ import { UnifyIntentAgent } from './agent';
 import { isIntentClient, validateEmail } from './utils/helpers';
 import { logUnifyError } from './utils/logging';
 import { DEFAULT_SESSION_MINUTES_TO_EXPIRE } from './constants';
+import { TrackActivity } from './activities/track';
 
 declare global {
   interface Window {
@@ -200,6 +203,44 @@ export default class UnifyIntentClient {
       });
       return action.getTrackPayload();
     }
+  };
+
+  /**
+   * This function logs a track event with the given name and properties
+   * to the Unify Intent API. Unify will associate this event
+   * with the current user's session and all related activities.
+   *
+   * @param name - the name of the event to track, e.g. "Demo Button Clicked"
+   * @param properties - optional properties to associate with the event
+   */
+  public track = (
+    name: string,
+    properties: TrackEventData['properties'],
+  ): void => {
+    if (!this._mounted) return;
+
+    const action = new TrackActivity(this._context, { name, properties });
+    action.track();
+  };
+
+  /**
+   * This function returns the request payload for a single track event.
+   * This is useful if you want to send the payload to a proxy server to
+   * perform the tracking server-side.
+   *
+   * @param name - the name of the event to track, e.g. "Demo Button Clicked"
+   * @param properties - optional properties to associate with the event
+   * @returns if the client is mounted, the request payload for a track event,
+   *          otherwise `undefined`
+   */
+  public getTrackPayload = (
+    name: string,
+    properties: TrackEventData['properties'],
+  ): (AnalyticsEventBase & TrackEventData) | undefined => {
+    if (!this._mounted) return;
+
+    const action = new TrackActivity(this._context, { name, properties });
+    return action.getTrackPayload();
   };
 
   /**

--- a/src/spec.ts
+++ b/src/spec.ts
@@ -214,6 +214,92 @@ export interface components {
       /** @description URL of the page (equivalent to `location.href`). */
       url?: string;
     };
+    /** @description Track event. */
+    TrackEvent: {
+      /**
+       * @description Type of analytics event being sent.
+       * @enum {string}
+       */
+      type: "track";
+      /** @description Persistent identifier (e.g., database ID) for the user. */
+      userId?: string;
+      /** @description Identifier for the user when a persistent ID is not available. */
+      anonymousUserId: string;
+      /** @description Unique identifier for the user session. */
+      sessionId: string;
+      /**
+       * Format: date-time
+       * @description Event timestamp of the activity.
+       */
+      timestamp: string;
+      /**
+       * Format: date-time
+       * @description Timestamp at which the request is sent.
+       *
+       * Typically, this value is nearly identical to `timestamp`. However in some
+       * situations there is latency between when the activity occurs and when it
+       * is sent to Unify.
+       */
+      sentAt?: string;
+      /** @description Contextual information about the user behind the activity. */
+      context: components["schemas"]["ActivityContext"];
+      /**
+       * @deprecated
+       * @description Fingerprint information attached to the request.
+       */
+      fingerprint?: {
+        visitorId?: string;
+        requestId?: string;
+      };
+      name: string;
+      properties?: {
+        [key: string]: unknown;
+      };
+      /** @description Information about the company associated with the visitor. */
+      company?: {
+        /** @description Unique identifier for the record. */
+        id: components["schemas"]["uuid"];
+        /**
+         * Format: date-time
+         * @description Date and time the record was created.
+         */
+        createdAt: string;
+        /**
+         * Format: date-time
+         * @description Date and time the record was last updated.
+         */
+        updatedAt: string;
+        /** @description Name of the company. */
+        name?: string;
+        /** @description Website domain of the company. */
+        domain: string;
+        /** @description Physical address of the company. */
+        address?: components["schemas"]["UTypes.UAddress"];
+      };
+      /** @description Information about the person associated with the visitor. */
+      person?: {
+        /** @description Unique identifier for the record. */
+        id: components["schemas"]["uuid"];
+        /**
+         * Format: date-time
+         * @description Date and time the record was created.
+         */
+        createdAt: string;
+        /**
+         * Format: date-time
+         * @description Date and time the record was last updated.
+         */
+        updatedAt: string;
+        /** @description Email address of the person. */
+        email: string;
+        /** @description Physical address of the person. */
+        address?: components["schemas"]["UTypes.UAddress"];
+        /** @description First name of the person. */
+        firstName?: string;
+        /** @description Last name of the person. */
+        lastName?: string;
+      };
+    };
     /** @description Traits for the identify request payload. */
     Traits: {
       /** @description Email address of the visitor. */
@@ -249,6 +335,8 @@ export interface components {
     ipv4: string;
     /** Format: ipv6 */
     ipv6: string;
+    /** Format: uuid */
+    uuid: string;
   };
   responses: never;
   parameters: never;

--- a/src/tests/client/activities/track.unit.test.ts
+++ b/src/tests/client/activities/track.unit.test.ts
@@ -1,0 +1,61 @@
+import { anyObject, mockReset } from 'jest-mock-extended';
+
+import { TrackEventData } from '../../../types';
+import { MockClientSession, TEST_VISITOR_ID } from '../../mocks/data';
+import { MockUnifyIntentContext } from '../../mocks/intent-context-mock';
+import {
+  TrackActivity,
+  UNIFY_INTENT_TRACK_URL,
+} from '../../../client/activities/track';
+
+describe('TrackActivity', () => {
+  const mockContext = MockUnifyIntentContext();
+
+  beforeEach(() => {
+    mockReset(mockContext.apiClient);
+    mockReset(mockContext.identityManager);
+    mockReset(mockContext.sessionManager);
+  });
+
+  describe('track', () => {
+    beforeEach(() => {
+      mockContext.sessionManager.getOrCreateSession.mockReturnValue(
+        MockClientSession(),
+      );
+      mockContext.identityManager.getOrCreateVisitorId.mockReturnValue(
+        TEST_VISITOR_ID,
+      );
+    });
+
+    it('tracks a track activity with name and properties', () => {
+      const activity = new TrackActivity(mockContext, {
+        name: 'Test Event',
+        properties: { customProperty: 'Test' },
+      });
+      activity.track();
+      expect(mockContext.apiClient.post).toHaveBeenCalledWith(
+        UNIFY_INTENT_TRACK_URL,
+        anyObject(),
+      );
+      const data = mockContext.apiClient.post.mock
+        .calls[0][1] as TrackEventData;
+      expect(data.type).toEqual('track');
+      expect(data.name).toEqual('Test Event');
+      expect(data.properties).toEqual({ customProperty: 'Test' });
+    });
+
+    it('tracks a track activity when no properties provided', () => {
+      const activity = new TrackActivity(mockContext, { name: 'Test Event' });
+      activity.track();
+      expect(mockContext.apiClient.post).toHaveBeenCalledWith(
+        UNIFY_INTENT_TRACK_URL,
+        anyObject(),
+      );
+      const data = mockContext.apiClient.post.mock
+        .calls[0][1] as TrackEventData;
+      expect(data.type).toEqual('track');
+      expect(data.name).toEqual('Test Event');
+      expect(data.properties).toBeUndefined();
+    });
+  });
+});

--- a/src/tests/client/agent/utils.unit.test.ts
+++ b/src/tests/client/agent/utils.unit.test.ts
@@ -6,7 +6,7 @@ import {
 import {
   extractUnifyCapturePropertiesFromElement,
   getElementName,
-  isActionableButton,
+  isActionableElement,
 } from '../../../client/agent/utils';
 
 describe('Unify Intent Agent utils', () => {
@@ -22,37 +22,37 @@ describe('Unify Intent Agent utils', () => {
     });
 
     it('returns true when element is actionable', () => {
-      expect(isActionableButton(button)).toEqual(true);
+      expect(isActionableElement(button)).toEqual(true);
     });
 
     it('returns false when element is hidden', () => {
       button.hidden = true;
-      expect(isActionableButton(button)).toEqual(false);
+      expect(isActionableElement(button)).toEqual(false);
     });
 
     it('returns false when element is aria hidden', () => {
       button.setAttribute('aria-hidden', 'true');
-      expect(isActionableButton(button)).toEqual(false);
+      expect(isActionableElement(button)).toEqual(false);
     });
 
     it('returns false when element is visually hidden', () => {
       button.style.display = 'none';
-      expect(isActionableButton(button)).toEqual(false);
+      expect(isActionableElement(button)).toEqual(false);
     });
 
     it('returns false when element is disabled', () => {
       button.disabled = true;
-      expect(isActionableButton(button)).toEqual(false);
+      expect(isActionableElement(button)).toEqual(false);
     });
 
     it('returns false when element is aria disabled', () => {
       button.setAttribute('aria-disabled', 'true');
-      expect(isActionableButton(button)).toEqual(false);
+      expect(isActionableElement(button)).toEqual(false);
     });
 
     it('returns false when element is excluded', () => {
       button.dataset[UNIFY_ELEMENT_EXCLUSION_DATA_ATTR] = 'true';
-      expect(isActionableButton(button)).toEqual(false);
+      expect(isActionableElement(button)).toEqual(false);
     });
   });
 

--- a/src/tests/client/agent/utils.unit.test.ts
+++ b/src/tests/client/agent/utils.unit.test.ts
@@ -1,5 +1,5 @@
 import {
-  UNIFY_CAPTURE_ATTRIBUTES_DATA_ATTR_PREFIX,
+  UNIFY_ATTRIBUTES_DATA_ATTR_PREFIX,
   UNIFY_ELEMENT_EXCLUSION_DATA_ATTR,
   UNIFY_ELEMENT_LABEL_DATA_ATTR,
 } from '../../../client/agent/constants';
@@ -141,8 +141,8 @@ describe('Unify Intent Agent utils', () => {
     });
 
     it('returns extra attributes when there are any', () => {
-      button.dataset['unifyCaptureAttrCustomProperty'] = 'custom';
-      button.dataset['unifyCaptureAttrAnotherProperty'] = 'another';
+      button.dataset['unifyAttrCustomProperty'] = 'custom';
+      button.dataset['unifyAttrAnotherProperty'] = 'another';
       expect(extractUnifyCapturePropertiesFromElement(button)).toEqual({
         customProperty: 'custom',
         anotherProperty: 'another',

--- a/src/tests/client/agent/utils.unit.test.ts
+++ b/src/tests/client/agent/utils.unit.test.ts
@@ -1,0 +1,152 @@
+import {
+  UNIFY_CAPTURE_ATTRIBUTES_DATA_ATTR_PREFIX,
+  UNIFY_ELEMENT_EXCLUSION_DATA_ATTR,
+  UNIFY_ELEMENT_LABEL_DATA_ATTR,
+} from '../../../client/agent/constants';
+import {
+  extractUnifyCapturePropertiesFromElement,
+  getElementName,
+  isActionableButton,
+} from '../../../client/agent/utils';
+
+describe('Unify Intent Agent utils', () => {
+  describe('isActionableButton', () => {
+    let button: HTMLButtonElement;
+
+    beforeEach(() => {
+      button = document.createElement('button');
+    });
+
+    afterEach(() => {
+      button.remove();
+    });
+
+    it('returns true when element is actionable', () => {
+      expect(isActionableButton(button)).toEqual(true);
+    });
+
+    it('returns false when element is hidden', () => {
+      button.hidden = true;
+      expect(isActionableButton(button)).toEqual(false);
+    });
+
+    it('returns false when element is aria hidden', () => {
+      button.setAttribute('aria-hidden', 'true');
+      expect(isActionableButton(button)).toEqual(false);
+    });
+
+    it('returns false when element is visually hidden', () => {
+      button.style.display = 'none';
+      expect(isActionableButton(button)).toEqual(false);
+    });
+
+    it('returns false when element is disabled', () => {
+      button.disabled = true;
+      expect(isActionableButton(button)).toEqual(false);
+    });
+
+    it('returns false when element is aria disabled', () => {
+      button.setAttribute('aria-disabled', 'true');
+      expect(isActionableButton(button)).toEqual(false);
+    });
+
+    it('returns false when element is excluded', () => {
+      button.dataset[UNIFY_ELEMENT_EXCLUSION_DATA_ATTR] = 'true';
+      expect(isActionableButton(button)).toEqual(false);
+    });
+  });
+
+  describe('getElementName', () => {
+    let button: HTMLButtonElement;
+    let label: HTMLLabelElement;
+
+    beforeEach(() => {
+      button = document.createElement('button');
+      button.dataset[UNIFY_ELEMENT_LABEL_DATA_ATTR] = 'Unify label';
+      button.innerText = 'Inner text';
+      button.textContent = 'Text content';
+      button.setAttribute('aria-label', 'Aria label');
+      button.setAttribute('aria-labelledby', 'label-id');
+      document.body.appendChild(button);
+
+      label = document.createElement('label');
+      label.id = 'label-id';
+      label.innerText = 'Label';
+      document.body.appendChild(label);
+    });
+
+    afterEach(() => {
+      button.remove();
+      label.remove();
+    });
+
+    it('uses Unify data label first', () => {
+      expect(getElementName(button)).toEqual('Unify label');
+    });
+
+    it('uses inner text next', () => {
+      button.dataset[UNIFY_ELEMENT_LABEL_DATA_ATTR] = '';
+      expect(getElementName(button)).toEqual('Inner text');
+    });
+
+    it('uses text content next', () => {
+      button.dataset[UNIFY_ELEMENT_LABEL_DATA_ATTR] = '';
+      button.innerText = '';
+      expect(getElementName(button)).toEqual('Text content');
+    });
+
+    it('uses aria label next', () => {
+      button.dataset[UNIFY_ELEMENT_LABEL_DATA_ATTR] = '';
+      button.innerText = '';
+      button.textContent = '';
+      expect(getElementName(button)).toEqual('Aria label');
+    });
+
+    it('uses aria labelled by next', () => {
+      button.dataset[UNIFY_ELEMENT_LABEL_DATA_ATTR] = '';
+      button.innerText = '';
+      button.textContent = '';
+      button.setAttribute('aria-label', '');
+      expect(getElementName(button)).toEqual('Label');
+    });
+
+    it('uses nested image alt next', () => {
+      button.dataset[UNIFY_ELEMENT_LABEL_DATA_ATTR] = '';
+      button.innerText = '';
+      button.textContent = '';
+      button.setAttribute('aria-label', '');
+      button.setAttribute('aria-labelledby', '');
+
+      const image = document.createElement('img');
+      image.alt = 'Image alt';
+      button.append(image);
+
+      expect(getElementName(button)).toEqual('Image alt');
+    });
+  });
+
+  describe('extractUnifyCapturePropertiesFromElement', () => {
+    let button: HTMLButtonElement;
+
+    beforeEach(() => {
+      button = document.createElement('button');
+    });
+
+    afterEach(() => {
+      button.remove();
+    });
+
+    it('returns an empty object if no extra attributes', () => {
+      expect(extractUnifyCapturePropertiesFromElement(button)).toEqual({});
+    });
+
+    it('returns extra attributes when there are any', () => {
+      button.dataset['unifyCaptureAttrCustomProperty'] = 'custom';
+      button.dataset['unifyCaptureAttrAnotherProperty'] = 'another';
+      expect(extractUnifyCapturePropertiesFromElement(button)).toEqual({
+        customProperty: 'custom',
+        anotherProperty: 'another',
+      });
+    });
+  });
+});

--- a/src/tests/client/unify-intent-client.unit.test.ts
+++ b/src/tests/client/unify-intent-client.unit.test.ts
@@ -181,7 +181,7 @@ describe('UnifyIntentClient', () => {
       unify.mount();
 
       expect(mockedIntentAgent.startAutoTrack).not.toHaveBeenCalled();
-      unify.startAutoTrack({ trackButtonClicks: true });
+      unify.startAutoTrack({ clickTrackingSelectors: [] });
       expect(mockedIntentAgent.startAutoTrack).toHaveBeenCalledTimes(1);
 
       unify.unmount();
@@ -191,7 +191,7 @@ describe('UnifyIntentClient', () => {
   describe('stopAutoTrack', () => {
     it('tells the Unify Intent Agent to stop auto-tracking', () => {
       const unify = new UnifyIntentClient(TEST_WRITE_KEY, {
-        autoTrackOptions: { trackButtonClicks: true },
+        autoTrackOptions: { clickTrackingSelectors: [] },
       });
       unify.mount();
 
@@ -208,7 +208,7 @@ describe('UnifyIntentClient', () => {
       const unify = new UnifyIntentClient(TEST_WRITE_KEY, {
         autoPage: true,
         autoIdentify: true,
-        autoTrackOptions: { trackButtonClicks: true },
+        autoTrackOptions: { clickTrackingSelectors: [] },
       });
       unify.mount();
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,6 +51,11 @@ export interface UnifyIntentContext {
  * e.g. button clicks.
  */
 export interface AutoTrackOptions {
+  /**
+   * An optional list of CSS selectors which can be used to automatically
+   * track click events for elements on the page which match one or more
+   * of the selectors.
+   */
   clickTrackingSelectors?: string[];
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -51,16 +51,11 @@ export interface UnifyIntentContext {
  * e.g. button clicks.
  */
 export interface AutoTrackOptions {
-  /**
-   * Whether user button clicks should be auto-tracked. Includes `button`
-   * elements and other HTML elements with `role="button"`.
-   * @default false
-   */
-  trackButtonClicks?: boolean;
+  clickTrackingSelectors?: string[];
 }
 
 export enum UnifyStandardTrackEvent {
-  BUTTON_CLICKED = 'Button clicked',
+  ELEMENT_CLICKED = 'Element Clicked',
 }
 
 /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -21,6 +21,15 @@ export interface UnifyIntentClientConfig {
   autoIdentify?: boolean;
 
   /**
+   * These options can be specified to indicate that the Unify client
+   * should instantiate an agent which listens for common user actions
+   * such as button clicks and fires track events for these actions
+   * automatically.
+   * @default undefined
+   */
+  autoTrackOptions?: AutoTrackOptions;
+
+  /**
    * The amount of time in minutes that user sessions will persist even when
    * no activities are tracked for the user. Activities which update the
    * expiration time of sessions are `page`, `identify`, and `track` activities.
@@ -35,6 +44,23 @@ export interface UnifyIntentContext {
   apiClient: UnifyApiClient;
   sessionManager: SessionManager;
   identityManager: IdentityManager;
+}
+
+/**
+ * Options which can be used to automatically track common user actions,
+ * e.g. button clicks.
+ */
+export interface AutoTrackOptions {
+  /**
+   * Whether user button clicks should be auto-tracked. Includes `button`
+   * elements and other HTML elements with `role="button"`.
+   * @default false
+   */
+  trackButtonClicks?: boolean;
+}
+
+export enum UnifyStandardTrackEvent {
+  BUTTON_CLICKED = 'Button clicked',
 }
 
 /**
@@ -61,7 +87,7 @@ export interface UserAgentDataType {
 }
 
 // Export types from the OpenAPI spec
-export type ActivityContext = components['schemas']['ActivityContext'];
+export type ActivityContext = components['schemas']['EventContext'];
 export type AnalyticsEventType = components['schemas']['AnalyticsEventType'];
 export type AnalyticsEventBase = components['schemas']['AnalyticsEventBase'];
 export type CampaignParams = components['schemas']['CampaignParams'];
@@ -82,4 +108,4 @@ export type TrackEventData = Omit<
 >;
 export type PageProperties = components['schemas']['PageProperties'];
 export type Traits = components['schemas']['Traits'];
-export type UCountryCode = components['schemas']['UCountryCode'];
+export type UCountryCode = components['schemas']['UValues.UCountryCode'];

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,6 +75,11 @@ export type PageEventData = Omit<
   components['schemas']['PageEvent'],
   keyof Omit<AnalyticsEventBase, 'type'>
 >;
+export type TrackEvent = components['schemas']['TrackEvent'];
+export type TrackEventData = Omit<
+  components['schemas']['TrackEvent'],
+  keyof Omit<AnalyticsEventBase, 'type'>
+>;
 export type PageProperties = components['schemas']['PageProperties'];
 export type Traits = components['schemas']['Traits'];
 export type UCountryCode = components['schemas']['UCountryCode'];

--- a/test.html
+++ b/test.html
@@ -7,6 +7,7 @@
         var e = [
           'identify',
           'page',
+          'track',
           'startAutoPage',
           'stopAutoPage',
           'startAutoIdentify',

--- a/test.html
+++ b/test.html
@@ -8,10 +8,12 @@
           'identify',
           'page',
           'track',
-          'startAutoPage',
-          'stopAutoPage',
           'startAutoIdentify',
           'stopAutoIdentify',
+          'startAutoPage',
+          'stopAutoPage',
+          'startAutoTrack',
+          'stopAutoTrack',
         ];
         function t(o) {
           return Object.assign(
@@ -42,6 +44,16 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
-    <div id="root"></div>
+    <div id="root">
+      <div style="display: flex; align-items: center; gap: 16px">
+        <button>Simple track</button>
+        <button data-unify-capture-attr-custom="test">
+          Track custom attrs
+        </button>
+        <button data-unify-label="Custom Button Name">
+          Track custom label
+        </button>
+      </div>
+    </div>
   </body>
 </html>


### PR DESCRIPTION
This PR adds the `track` method to the Unify Intent Client which will leverage the new Track API to allow for the logging of custom events and properties for use within Unify.

See the updated README for an in-depth explanation of the new methods.