### PR TITLE
Add event buffers which are processed after client is mounted

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unifygtm/intent-client",
-  "version": "1.6.0",
+  "version": "1.8.0",
   "description": "JavaScript client for interacting with the Unify Intent API in the browser.",
   "keywords": [
     "unify",

--- a/src/tests/client/unify-intent-client.unit.test.ts
+++ b/src/tests/client/unify-intent-client.unit.test.ts
@@ -110,6 +110,26 @@ describe('UnifyIntentClient', () => {
 
       unify.unmount();
     });
+
+    describe('when client is not mounted', () => {
+      it('buffers an event until it is mounted', () => {
+        const unify = new UnifyIntentClient(TEST_WRITE_KEY, {
+          autoPage: false,
+        });
+
+        expect(mockedPageActivity.track).not.toHaveBeenCalled();
+        unify.page();
+        unify.page({ pathname: '/hello' });
+        expect(mockedPageActivity.track).not.toHaveBeenCalled();
+
+        expect(unify.__getEventBuffers().page.length).toEqual(2);
+        unify.mount();
+        expect(mockedPageActivity.track).toHaveBeenCalledTimes(2);
+        expect(unify.__getEventBuffers().page.length).toEqual(0);
+
+        unify.unmount();
+      });
+    });
   });
 
   describe('identify', () => {
@@ -132,6 +152,28 @@ describe('UnifyIntentClient', () => {
 
       unify.unmount();
     });
+
+    describe('when client is not mounted', () => {
+      it('buffers an event until it is mounted', () => {
+        const unify = new UnifyIntentClient(TEST_WRITE_KEY, {
+          autoIdentify: false,
+        });
+
+        expect(mockedIdentifyActivity.track).not.toHaveBeenCalled();
+        unify.identify('solomon@unifygtm.com');
+        unify.identify('solomon2@unifygtm.com', {
+          person: { email: 'solomon2@unifygtm.com' },
+        });
+        expect(mockedIdentifyActivity.track).not.toHaveBeenCalled();
+
+        expect(unify.__getEventBuffers().identify.length).toEqual(2);
+        unify.mount();
+        expect(mockedIdentifyActivity.track).toHaveBeenCalledTimes(2);
+        expect(unify.__getEventBuffers().identify.length).toEqual(0);
+
+        unify.unmount();
+      });
+    });
   });
 
   describe('track', () => {
@@ -144,6 +186,26 @@ describe('UnifyIntentClient', () => {
       expect(mockedTrackActivity.track).toHaveBeenCalledTimes(1);
 
       unify.unmount();
+    });
+
+    describe('when client is not mounted', () => {
+      it('buffers an event until it is mounted', () => {
+        const unify = new UnifyIntentClient(TEST_WRITE_KEY);
+
+        expect(mockedTrackActivity.track).not.toHaveBeenCalled();
+        unify.track('Button clicked');
+        unify.track('Button clicked', {
+          properties: { customProperty: 'true' },
+        });
+        expect(mockedTrackActivity.track).not.toHaveBeenCalled();
+
+        expect(unify.__getEventBuffers().track.length).toEqual(2);
+        unify.mount();
+        expect(mockedTrackActivity.track).toHaveBeenCalledTimes(2);
+        expect(unify.__getEventBuffers().track.length).toEqual(0);
+
+        unify.unmount();
+      });
     });
   });
 


### PR DESCRIPTION
There appears to be a flaw in the Unify intent React provider where the recommended code for identifying a user in your app does not work because the intent client has not been mounted by the time the code calls `unify.identify`.

I tried adding some changes to the react library to make this work, but ultimately the best way seems to be to buffer calls to `page`, `identify`, and `track` before the client is mounted, and then flush that buffer once the client is mounted. This PR implements that in the intent client.